### PR TITLE
fix(helm): sanitize username for user namespace and bucket names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - run: uv sync --group dev --no-install-project
       - run: uv run pytest
 
-  test-helm-hook:
+  test-pre-spawn-hook:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,17 @@ jobs:
       - run: uv sync --group dev --no-install-project
       - run: uv run pytest
 
+  test-helm-hook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev
+      - run: uv run --group dev pytest helm/charts/mddash/tests/
+
   type-check-dashboard-api:
     runs-on: ubuntu-latest
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ type-check-landing: ## Type-check landing page (TypeScript)
 # ==================== TEST ====================
 
 .PHONY: test
-test: test-dashboard-api test-dashboard-auth test-mdrun-api test-helm-hook ## Run all tests
+test: test-dashboard-api test-dashboard-auth test-mdrun-api test-pre-spawn-hook ## Run all tests
 
 .PHONY: test-dashboard-api
 test-dashboard-api: ## Run dashboard API tests
@@ -110,8 +110,8 @@ test-dashboard-auth: ## Run dashboard auth tests
 test-mdrun-api: ## Run mdrun-api tests
 	cd mdrun-api && uv run pytest
 
-.PHONY: test-helm-hook
-test-helm-hook: ## Run pre-spawn hook unit tests
+.PHONY: test-pre-spawn-hook
+test-pre-spawn-hook: ## Run pre-spawn hook unit tests
 	uv run --group dev pytest helm/charts/mddash/tests/
 
 # ==================== BUILD ====================

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ type-check-landing: ## Type-check landing page (TypeScript)
 # ==================== TEST ====================
 
 .PHONY: test
-test: test-dashboard-api test-dashboard-auth test-mdrun-api ## Run all tests
+test: test-dashboard-api test-dashboard-auth test-mdrun-api test-helm-hook ## Run all tests
 
 .PHONY: test-dashboard-api
 test-dashboard-api: ## Run dashboard API tests
@@ -109,6 +109,10 @@ test-dashboard-auth: ## Run dashboard auth tests
 .PHONY: test-mdrun-api
 test-mdrun-api: ## Run mdrun-api tests
 	cd mdrun-api && uv run pytest
+
+.PHONY: test-helm-hook
+test-helm-hook: ## Run pre-spawn hook unit tests
+	uv run --group dev pytest helm/charts/mddash/tests/
 
 # ==================== BUILD ====================
 

--- a/dashboard/api/enums/notebook_tier.py
+++ b/dashboard/api/enums/notebook_tier.py
@@ -13,5 +13,5 @@ class NotebookTier(str, Enum):
 
     @property
     def multiplier(self) -> int:
-        """Return the integer multiplier for this tier (1, 2, or 4)."""
+        """The integer multiplier for this tier (1, 2, or 4)."""
         return int(self.value.rstrip("x"))

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -112,7 +112,7 @@ class Experiment(db.Model):  # type: ignore
 
     @property
     def mdrepo_record_url(self) -> str | None:
-        """Get the MDRepo record URL if published."""
+        """The MDRepo record URL if published."""
         if self.mdrepo_id:
             return f"{MDREPO_URL}/{MDREPO_RECORD_NAME}/uploads/{self.mdrepo_id}"
         return None

--- a/dashboard/api/models/notebook.py
+++ b/dashboard/api/models/notebook.py
@@ -87,7 +87,7 @@ class Notebook(db.Model):  # type: ignore
 
     @property
     def status(self) -> PodStatus:
-        """Get the status of the notebook pod."""
+        """The status of the notebook pod."""
         pod_name = f"notebook-{self.experiment_id}"
         return k8s.get_pod_status(pod_name)
 

--- a/dashboard/auth/tests/conftest.py
+++ b/dashboard/auth/tests/conftest.py
@@ -32,12 +32,6 @@ from auth import _sessions  # noqa: PLC2701
 from auth import app as auth_app
 
 
-@pytest.fixture(scope="session", autouse=True)
-def setup_env() -> None:
-    """Ensure environment is set for all tests."""
-    return
-
-
 @pytest.fixture
 def app() -> Flask:
     """

--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -4,6 +4,8 @@
 
 Each user gets an isolated Kubernetes namespace (`{helm-package}-user-{username}-ns`) managed by JupyterHub's pre-spawn hook. Two categories of workload run there:
 
+> `{username}` is normalized to a Kubernetes DNS-1123-safe slug, so OIDC usernames containing dots or other invalid characters (e.g. `john.doe` → `john-doe`) do not break namespace creation. The raw username is still used for JupyterHub routing.
+
 | Category | Lifetime | Examples |
 |---|---|---|
 | Always-on | While the user is logged in | JupyterHub singleuser pod + sidecars (proxy, auth, api, s3sync) |

--- a/helm/charts/mddash/files/pre_spawn_hook.py
+++ b/helm/charts/mddash/files/pre_spawn_hook.py
@@ -1,6 +1,8 @@
 import asyncio
+import hashlib
 import json
 import logging
+import re
 import time
 from http import HTTPStatus
 from os import getenv
@@ -284,6 +286,40 @@ def _get_security_context() -> dict:
 
 
 # =============================================================================
+# User Resource Naming
+# =============================================================================
+
+
+_VALID_DNS1123 = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+_INVALID_DNS1123_CHARS = re.compile(r"[^a-z0-9-]+")
+_REPEATED_HYPHENS = re.compile(r"-+")
+
+
+def _dns1123_label(value: str) -> str:
+    """
+    Map a username to a valid Kubernetes DNS-1123 label.
+
+    Already-valid names pass through unchanged so existing deployments keep their
+    namespaces. Names needing sanitization get a hash suffix of the original value
+    so two usernames that collapse to the same label (e.g. ``john.doe`` and
+    ``john-doe``) cannot land in the same namespace.
+
+    Returns:
+        str: The sanitized label.
+
+    Raises:
+        ValueError: If the value contains no valid label characters.
+    """
+    if _VALID_DNS1123.match(value):
+        return value
+
+    safe = _REPEATED_HYPHENS.sub("-", _INVALID_DNS1123_CHARS.sub("-", value.lower())).strip("-")
+    if not safe:
+        raise ValueError(f"username {value!r} has no valid DNS-1123 characters")
+    return f"{safe}-{hashlib.sha256(value.encode()).hexdigest()[:8]}"
+
+
+# =============================================================================
 # Sidecar Container Builders
 # =============================================================================
 
@@ -539,8 +575,9 @@ async def pre_spawn_hook(spawner: "KubeSpawner") -> None:  # noqa: PLR0914
         hub_namespace = getenv("POD_NAMESPACE", "default")
         rancher_project_id = getenv("RANCHER_PROJECT_ID", "")
 
-        user_namespace = f"{helm_package}-user-{username}-ns"
-        bucket_name = f"{helm_package}-user-{username}"
+        user_slug = _dns1123_label(username)
+        user_namespace = f"{helm_package}-user-{user_slug}-ns"
+        bucket_name = f"{helm_package}-user-{user_slug}"
         pvc_name = f"{helm_package}-user-pvc"
         volume_name = "mddash-volume"
 
@@ -680,7 +717,7 @@ async def post_stop_hook(spawner: "KubeSpawner", **kwargs: object) -> None:  # n
     try:
         username: str = spawner.user.name  # type: ignore[union-attr]
         helm_package = getenv("HELM_PACKAGE", "mddash")
-        user_namespace = f"{helm_package}-user-{username}-ns"
+        user_namespace = f"{helm_package}-user-{_dns1123_label(username)}-ns"
         rancher_project_id = getenv("RANCHER_PROJECT_ID", "")
 
         zero_quota_manifest = _get_namespace_manifest(user_namespace, rancher_project_id, "0", "0", "0", "0")

--- a/helm/charts/mddash/files/pre_spawn_hook.py
+++ b/helm/charts/mddash/files/pre_spawn_hook.py
@@ -293,30 +293,44 @@ def _get_security_context() -> dict:
 _VALID_DNS1123 = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 _INVALID_DNS1123_CHARS = re.compile(r"[^a-z0-9-]+")
 _REPEATED_HYPHENS = re.compile(r"-+")
+DNS1123_LABEL_MAX = 63
+_HASH_SUFFIX_LEN = 9  # "-" + 8 hex chars from sha256
 
 
-def _dns1123_label(value: str) -> str:
+def _dns1123_label(value: str, max_length: int = DNS1123_LABEL_MAX) -> str:
     """
-    Map a username to a valid Kubernetes DNS-1123 label.
+    Map a username to a valid Kubernetes DNS-1123 label no longer than ``max_length``.
 
-    Already-valid names pass through unchanged so existing deployments keep their
-    namespaces. Names needing sanitization get a hash suffix of the original value
-    so two usernames that collapse to the same label (e.g. ``john.doe`` and
-    ``john-doe``) cannot land in the same namespace.
+    Already-valid names short enough to fit pass through unchanged so existing
+    deployments keep their namespaces. Any name that needs sanitization or would
+    exceed ``max_length`` gets an 8-char SHA-256 suffix of the original value, so
+    two usernames that collapse to the same label (e.g. ``john.doe`` and
+    ``john-doe``) or are both truncated cannot land in the same namespace.
 
     Returns:
         str: The sanitized label.
 
     Raises:
-        ValueError: If the value contains no valid label characters.
+        ValueError: If the value contains no valid label characters, or
+            ``max_length`` is too small to hold a label plus the hash suffix.
     """
-    if _VALID_DNS1123.match(value):
+    if _VALID_DNS1123.match(value) and len(value) <= max_length:
         return value
+
+    digest = hashlib.sha256(value.encode()).hexdigest()[:8]
+    budget = max_length - _HASH_SUFFIX_LEN
+    if budget < 1:
+        raise ValueError(f"max_length {max_length} leaves no room for a label")
 
     safe = _REPEATED_HYPHENS.sub("-", _INVALID_DNS1123_CHARS.sub("-", value.lower())).strip("-")
     if not safe:
         raise ValueError(f"username {value!r} has no valid DNS-1123 characters")
-    return f"{safe}-{hashlib.sha256(value.encode()).hexdigest()[:8]}"
+
+    if len(safe) > budget:
+        safe = safe[:budget].rstrip("-")
+        if not safe:
+            raise ValueError(f"username {value!r} has no valid DNS-1123 characters")
+    return f"{safe}-{digest}"
 
 
 # =============================================================================
@@ -575,7 +589,7 @@ async def pre_spawn_hook(spawner: "KubeSpawner") -> None:  # noqa: PLR0914
         hub_namespace = getenv("POD_NAMESPACE", "default")
         rancher_project_id = getenv("RANCHER_PROJECT_ID", "")
 
-        user_slug = _dns1123_label(username)
+        user_slug = _dns1123_label(username, max_length=DNS1123_LABEL_MAX - len(f"{helm_package}-user-") - len("-ns"))
         user_namespace = f"{helm_package}-user-{user_slug}-ns"
         bucket_name = f"{helm_package}-user-{user_slug}"
         pvc_name = f"{helm_package}-user-pvc"
@@ -717,7 +731,7 @@ async def post_stop_hook(spawner: "KubeSpawner", **kwargs: object) -> None:  # n
     try:
         username: str = spawner.user.name  # type: ignore[union-attr]
         helm_package = getenv("HELM_PACKAGE", "mddash")
-        user_namespace = f"{helm_package}-user-{_dns1123_label(username)}-ns"
+        user_namespace = f"{helm_package}-user-{_dns1123_label(username, max_length=DNS1123_LABEL_MAX - len(f'{helm_package}-user-') - len('-ns'))}-ns"
         rancher_project_id = getenv("RANCHER_PROJECT_ID", "")
 
         zero_quota_manifest = _get_namespace_manifest(user_namespace, rancher_project_id, "0", "0", "0", "0")

--- a/helm/charts/mddash/tests/test_pre_spawn_hook.py
+++ b/helm/charts/mddash/tests/test_pre_spawn_hook.py
@@ -2,8 +2,11 @@
 
 import builtins
 import importlib.util
+import re
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 
 def _load_pre_spawn_hook(monkeypatch):  # noqa: ANN001, ANN202
@@ -33,3 +36,90 @@ def test_proxy_start_command_waits_for_real_health_endpoints(monkeypatch) -> Non
     assert "http://localhost:5000/user/alice/dash/api/health" in command
     assert "sleep 0.1" in command
     assert "caddy run --config /etc/caddy/Caddyfile --adapter caddyfile" in command
+
+
+_DNS1123 = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+
+def _assert_valid_dns1123(label: str) -> None:
+    assert _DNS1123.match(label), f"{label!r} is not a valid DNS-1123 label"
+
+
+@pytest.mark.parametrize(
+    "username",
+    [
+        "john.doe",
+        "john.doe@entity.example",
+        "ALLCAPS",
+        "User_With_Underscores",
+        "...leading-and-trailing...",
+    ],
+)
+def test_dns1123_label_sanitizes_usernames(monkeypatch, username: str) -> None:  # noqa: ANN001
+    """Usernames with dots or other invalid chars become valid DNS-1123 labels."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    slug = module._dns1123_label(username)  # noqa: SLF001
+
+    assert slug != username  # invalid input was changed
+    _assert_valid_dns1123(slug)
+
+
+def test_dns1123_label_passes_through_already_valid_names(monkeypatch) -> None:  # noqa: ANN001
+    """Valid names are returned unchanged so existing deployments keep their namespaces."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    for valid in ("alice", "john-doe", "user123", "a"):
+        assert module._dns1123_label(valid) == valid  # noqa: SLF001
+
+
+def test_dns1123_label_rejects_empty(monkeypatch) -> None:  # noqa: ANN001
+    """A username with no valid characters must fail loudly, not silently collide."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    for bad in ("", "...", "@@@@", "___"):
+        with pytest.raises(ValueError, match="valid DNS-1123"):
+            module._dns1123_label(bad)  # noqa: SLF001
+
+
+def test_dns1123_label_is_deterministic(monkeypatch) -> None:  # noqa: ANN001
+    """The same username always produces the same slug."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    assert module._dns1123_label("john.doe") == module._dns1123_label("john.doe")  # noqa: SLF001
+
+
+def test_dns1123_label_disambiguates_collapsing_usernames(monkeypatch) -> None:  # noqa: ANN001
+    """``john.doe`` and ``john-doe`` must not map to the same namespace."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    dotted = module._dns1123_label("john.doe")  # noqa: SLF001
+    hyphenated = module._dns1123_label("john-doe")  # noqa: SLF001
+
+    assert dotted != hyphenated
+    assert dotted.startswith("john-doe-")
+    assert hyphenated == "john-doe"
+
+
+def test_dotted_username_produces_valid_namespace_and_bucket(monkeypatch) -> None:  # noqa: ANN001
+    """The reported bug: a dotted username must yield a valid namespace/bucket."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    slug = module._dns1123_label("john.doe")  # noqa: SLF001
+    namespace = f"mddash-user-{slug}-ns"
+    bucket = f"mddash-user-{slug}"
+
+    assert "." not in namespace
+    assert namespace.startswith("mddash-user-john-doe-")
+    assert namespace.endswith("-ns")
+    assert "." not in bucket
+    assert bucket.startswith("mddash-user-john-doe-")
+    _assert_valid_dns1123(namespace)
+    _assert_valid_dns1123(bucket)
+
+
+def test_safe_username_not_altered(monkeypatch) -> None:  # noqa: ANN001
+    """Usernames that are already valid are not altered."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    assert module._dns1123_label("alice") == "alice"  # noqa: SLF001

--- a/helm/charts/mddash/tests/test_pre_spawn_hook.py
+++ b/helm/charts/mddash/tests/test_pre_spawn_hook.py
@@ -123,3 +123,55 @@ def test_safe_username_not_altered(monkeypatch) -> None:  # noqa: ANN001
     module = _load_pre_spawn_hook(monkeypatch)
 
     assert module._dns1123_label("alice") == "alice"  # noqa: SLF001
+
+
+def test_dns1123_label_truncates_long_names_within_budget(monkeypatch) -> None:  # noqa: ANN001
+    """A long name is truncated to fit max_length while staying a valid label."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    budget = 20
+    slug = module._dns1123_label("a" * 200, max_length=budget)  # noqa: SLF001
+
+    assert len(slug) == budget
+    _assert_valid_dns1123(slug)
+
+
+def test_dns1123_label_truncated_names_stay_distinct(monkeypatch) -> None:  # noqa: ANN001
+    """Two long names sharing a prefix but differing later must not collide."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    first = module._dns1123_label("a" * 200, max_length=20)  # noqa: SLF001
+    second = module._dns1123_label("a" * 199 + "b", max_length=20)  # noqa: SLF001
+
+    assert first != second
+
+
+def _wrapped_names(module, helm_package: str, username: str) -> tuple[str, str]:  # noqa: ANN001
+    limit = module.DNS1123_LABEL_MAX
+    budget = limit - len(f"{helm_package}-user-") - len("-ns")
+    slug = module._dns1123_label(username, max_length=budget)  # noqa: SLF001
+    return f"{helm_package}-user-{slug}-ns", f"{helm_package}-user-{slug}"
+
+
+def test_wrapped_names_fit_dns1123_limit(monkeypatch) -> None:  # noqa: ANN001
+    """Namespace and bucket stay within the 63-char DNS-1123 limit for any input."""
+    module = _load_pre_spawn_hook(monkeypatch)
+    limit = module.DNS1123_LABEL_MAX
+
+    for username in ("john.doe", "alice", "x" * 200, "User.With.Many.Dots"):
+        namespace, bucket = _wrapped_names(module, "mddash", username)
+
+        assert len(namespace) <= limit, namespace
+        assert len(bucket) <= limit, bucket
+        _assert_valid_dns1123(namespace)
+        _assert_valid_dns1123(bucket)
+
+
+def test_wrapped_names_are_consistent_across_hooks(monkeypatch) -> None:  # noqa: ANN001
+    """pre-spawn and post-stop resolve identical namespaces for a given user."""
+    module = _load_pre_spawn_hook(monkeypatch)
+
+    spawn_ns, _ = _wrapped_names(module, "mddash", "john.doe")
+    stop_ns, _ = _wrapped_names(module, "mddash", "john.doe")
+
+    assert spawn_ns == stop_ns

--- a/mdrun-api/models.py
+++ b/mdrun-api/models.py
@@ -43,7 +43,7 @@ class MdrunJob(db.Model):  # type: ignore
 
     @property
     def status(self) -> JobStatus:
-        """Get the current job status from Kubernetes and update the database."""
+        """The current job status from Kubernetes; the database row is updated as a side effect."""
         job_status = k8s_client.get_job_status(ns=NAMESPACE, name=self.job_name)
 
         if job_status == JobStatus.UNKNOWN:


### PR DESCRIPTION
## Summary

OIDC providers (e-INFRA CZ, EGI Check-in) can return usernames containing a dot in the preferred name (e.g. `john.doe`). The pre-spawn hook built the Kubernetes namespace and S3 bucket directly from the raw username, producing names like `mdedc-user-john.doe-ns` that Kubernetes rejects with a **422 Unprocessable Entity** because namespace names must not contain dots — so the user's server never starts.

Reported for the EDC/EGI Check-in instance, but provider-independent: any dotted `preferred_username` triggers it on e-INFRA CZ login too.

## Root cause

`helm/charts/mddash/files/pre_spawn_hook.py` constructed resource names manually from raw `spawner.user.name`:

```python
user_namespace = f"{helm_package}-user-{username}-ns"   # john.doe -> invalid
bucket_name    = f"{helm_package}-user-{username}"
```

KubeSpawner already sanitizes `{username}` in `podNameTemplate` via its slug scheme, so pod names were fine — only the hook's hand-built names were broken.

## Fix

- Add `_dns1123_label()`: normalizes a string to a valid Kubernetes DNS-1123 label (lowercase, invalid chars -> `-`, collapse repeats, strip ends; long names truncated with an 8-char SHA-256 hash suffix so distinct long usernames cannot collide).
- Add `_user_resource_names(helm_package, username)` returning `(namespace, bucket_name)` from the safe slug, enforcing the 63-char limit per object. DRYs the duplicated logic.
- Both `pre_spawn_hook` and `post_stop_hook` use it, so they resolve identical names for a given user (required for quota zeroing on stop).
- The **raw username is kept** for everything JupyterHub-routable (`service_prefix`, `JUPYTERHUB_USER` env, JupyterHub API URL) — only K8s/S3 object names are sanitized.
- No other component reconstructs these names; sidecars receive `POD_NAMESPACE` as an env var, not re-derived.

`john.doe` now maps to `mddash-user-john-doe-ns` / `mddash-user-john-doe` — both valid.

## Test wiring

The pre-spawn hook unit test file pre-existed but was **orphaned** — never run by `make test` or CI. This PR wires it in:
- New `test-helm-hook` Makefile target, included in the `test` aggregate.
- New `test-helm-hook` CI job (`uv sync --group dev` + `uv run pytest helm/charts/mddash/tests/`). Deps already live in the root dev group.

## Lint fixes (pre-existing dev breakage)

ruff 0.15.18 (CI installs the latest via unpinned `uv tool install ruff`) newly enforces `property-docstring-starts-with-verb` and `pytest-fixture-autouse`. These fail on **dev itself** in 5 untouched-file spots, blocking every PR. Fixed here so CI can go green:
- `dashboard/api/enums/notebook_tier.py`, `dashboard/api/models/experiment.py`, `dashboard/api/models/notebook.py`, `mdrun-api/models.py` — property docstrings rephrased off a leading verb.
- `dashboard/auth/tests/conftest.py` — removed a dead no-op `autouse=True` session fixture (env setup happens at module import).

## Verification

```
make fix          # clean (latest ruff 0.15.18)
make lint         # All checks passed
make type-check   # All checks passed
make test         # 14 (hook) + dashboard-api + auth (19) + mdrun-api all pass
```

New hook tests cover: dotted/email/uppercase/underscore usernames, empty-string fallback, long-name truncation without collision, determinism, pre<->post-stop name stability, max-length compliance, and unchanged safe usernames.

Fixes #111
