### PR TITLE
Login via token in URL

### DIFF
--- a/dashboard/auth/auth.py
+++ b/dashboard/auth/auth.py
@@ -3,6 +3,7 @@ import hmac
 import logging
 import os
 import secrets
+import threading
 import time
 from http import HTTPStatus
 
@@ -10,6 +11,7 @@ import requests
 from flask import Flask, Response, make_response, redirect, request
 
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 4096
 
 logger = logging.getLogger(__name__)
 _first_health_logged = False
@@ -39,9 +41,34 @@ HMAC_SHA256_HEX_LENGTH = 64
 
 # {token: (username, expiry_timestamp)}
 _sessions: dict[str, tuple[str, float]] = {}
+_login_tokens: dict[str, tuple[str, float]] = {}
+_token_store_lock = threading.Lock()
 SESSION_LIFETIME = 3600  # 1 hour
 _last_cleanup = time.time()
 CLEANUP_INTERVAL = 300  # 5 minutes
+
+LOGIN_TOKEN_PAGE = """<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>MDDash login</title></head>
+<body><p id="status">Signing in...</p><script>
+const status = document.getElementById("status");
+const token = new URLSearchParams(window.location.hash.slice(1)).get("token");
+window.history.replaceState(null, "", window.location.pathname);
+if (!token) {
+  status.textContent = "Invalid login link.";
+} else {
+  fetch(window.location.pathname, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({token})
+  }).then(async response => {
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Login failed.");
+    window.location.replace(result.redirect_url);
+  }).catch(error => { status.textContent = error.message; });
+}
+</script></body>
+</html>"""
 
 
 def remove_expired_sessions() -> None:
@@ -54,9 +81,13 @@ def remove_expired_sessions() -> None:
 
     _last_cleanup = now
 
-    expired = [t for t, (_, exp) in _sessions.items() if exp < now]
-    for t in expired:
-        del _sessions[t]
+    with _token_store_lock:
+        expired = [t for t, (_, exp) in _sessions.items() if exp < now]
+        for t in expired:
+            del _sessions[t]
+        expired_login_tokens = [t for t, (_, exp) in _login_tokens.items() if exp < now]
+        for t in expired_login_tokens:
+            del _login_tokens[t]
 
 
 def is_valid_session(token: str, user: str) -> bool:
@@ -69,7 +100,8 @@ def is_valid_session(token: str, user: str) -> bool:
     if not token:
         return False
     now = time.time()
-    username, expiry = _sessions.get(token, (None, 0))
+    with _token_store_lock:
+        username, expiry = _sessions.get(token, (None, 0))
     return username == user and expiry > now
 
 
@@ -82,8 +114,38 @@ def create_session(user: str) -> str:
     """
     token = secrets.token_urlsafe(32)
     expiry = time.time() + SESSION_LIFETIME
-    _sessions[token] = (user, expiry)
+    with _token_store_lock:
+        _sessions[token] = (user, expiry)
     return token
+
+
+def create_login_token_value(user: str) -> str:
+    """
+    Create a one-time credential kept separate from browser sessions.
+
+    Returns:
+        str: A URL-safe random login token.
+    """
+    token = secrets.token_urlsafe(32)
+    expiry = time.time() + SESSION_LIFETIME
+    with _token_store_lock:
+        _login_tokens[token] = (user, expiry)
+    return token
+
+
+def consume_login_token(token: str, user: str) -> bool:
+    """
+    Atomically remove and validate a one-time login token.
+
+    Returns:
+        bool: True if the token existed, belonged to the user, and had not expired.
+    """
+    with _token_store_lock:
+        session = _login_tokens.pop(token, None)
+    if session is None:
+        return False
+    username, expiry = session
+    return username == user and expiry > time.time()
 
 
 def sign(data: str) -> str:
@@ -183,11 +245,10 @@ def create_login_token() -> tuple[dict, int]:
     Generate a one-time use login token for passwordless access.
 
     This endpoint must be called from an already authenticated session.
-    It creates a new session token and returns it so the client can construct
-    a shareable login URL.
+    It creates a new session token and returns a shareable login URL.
 
     Returns:
-        JSON response with 'token' and 'login_url' fields.
+        JSON response with 'login_url' and 'expires_in' fields.
     """
     # Check that caller has a valid session (already authenticated)
     auth_token = request.cookies.get(COOKIE_NAME)
@@ -195,46 +256,51 @@ def create_login_token() -> tuple[dict, int]:
         return {"error": "Authentication required"}, HTTPStatus.UNAUTHORIZED
 
     # Create a new session token for passwordless access
-    login_token_val = create_session(USER)
+    login_token_val = create_login_token_value(USER)
 
     # Construct the one-time login URL
-    login_url = f"{SERVICE_PREFIX}/dash/auth/login-token?token={login_token_val}"
+    login_url = f"{SERVICE_PREFIX}/dash/auth/login-token#token={login_token_val}"
 
     logger.info("Passwordless login token created for user %s", USER)
 
-    return {"token": login_token_val, "login_url": login_url, "expires_in": SESSION_LIFETIME}, HTTPStatus.OK
+    return {"login_url": login_url, "expires_in": SESSION_LIFETIME}, HTTPStatus.OK
 
 
-@app.route("/login-token")
+@app.route("/login-token", methods=["GET", "POST"])
 def login_token_endpoint() -> Response:
     """
-    Consume a one-time login token and establish a session cookie.
+    Serve the login page or consume a one-time token from a POST body.
 
-    Query params:
-        token: The one-time use token obtained from /create-login-token
+    The GET response reads the token from the URL fragment in the browser and
+    submits it as JSON to POST, keeping it out of request URLs and referrers.
 
     Returns:
-        Redirect to dashboard home with mddash-auth cookie set, or error response.
+        Login page for GET, or JSON with a redirect target for POST.
     """
-    token = request.args.get("token")
+    if request.method == "GET":
+        resp = make_response(LOGIN_TOKEN_PAGE, HTTPStatus.OK)
+        resp.headers["Content-Type"] = "text/html; charset=utf-8"
+        resp.headers["Cache-Control"] = "no-store"
+        resp.headers["Referrer-Policy"] = "no-referrer"
+        return resp
 
-    if not token:
-        return make_response("Missing token parameter", HTTPStatus.BAD_REQUEST)
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return make_response({"error": "Invalid JSON payload"}, HTTPStatus.BAD_REQUEST)
+    token = payload.get("token")
 
-    # Validate the token exists and belongs to this user
-    if not is_valid_session(token, USER):
+    if not isinstance(token, str) or not token:
+        return make_response({"error": "Missing token"}, HTTPStatus.BAD_REQUEST)
+
+    if not consume_login_token(token, USER):
         logger.warning("Invalid or expired login token attempted for user %s", USER)
-        return make_response("Invalid or expired token", HTTPStatus.UNAUTHORIZED)
-
-    # Token is valid - consume it (one-time use) and set cookie
-    # Remove from session store to prevent reuse
-    _sessions.pop(token, None)
+        return make_response({"error": "Invalid or expired token"}, HTTPStatus.UNAUTHORIZED)
 
     # Create a fresh session for the browser
     new_token = create_session(USER)
 
-    resp = make_response(redirect(f"{SERVICE_PREFIX}/dash/"))
-    resp.set_cookie(COOKIE_NAME, new_token, path=SERVICE_PREFIX, httponly=True, samesite="Lax")
+    resp = make_response({"redirect_url": f"{SERVICE_PREFIX}/dash/"}, HTTPStatus.OK)
+    resp.set_cookie(COOKIE_NAME, new_token, path=SERVICE_PREFIX, secure=True, httponly=True, samesite="Lax")
 
     logger.info("Passwordless login successful for user %s", USER)
     return resp

--- a/dashboard/auth/auth.py
+++ b/dashboard/auth/auth.py
@@ -11,7 +11,6 @@ import requests
 from flask import Flask, Response, make_response, redirect, request
 
 app = Flask(__name__)
-app.config["MAX_CONTENT_LENGTH"] = 4096
 
 logger = logging.getLogger(__name__)
 _first_health_logged = False
@@ -46,20 +45,6 @@ _token_store_lock = threading.Lock()
 SESSION_LIFETIME = 3600  # 1 hour
 _last_cleanup = time.time()
 CLEANUP_INTERVAL = 300  # 5 minutes
-
-LOGIN_TOKEN_BOOTSTRAP = """<script>
-const token = new URLSearchParams(window.location.hash.slice(1)).get("token");
-window.history.replaceState(null, "", window.location.pathname);
-fetch(window.location.pathname, {
-  method: "POST",
-  headers: {"Content-Type": "application/json"},
-  body: JSON.stringify({token})
-}).then(async response => {
-  const result = await response.json();
-  if (!response.ok) throw new Error(result.error || "Login failed.");
-  window.location.replace(result.redirect_url);
-}).catch(error => { document.body.textContent = error.message; });
-</script>"""
 
 
 def remove_expired_sessions() -> None:
@@ -236,10 +221,10 @@ def create_login_token() -> tuple[dict, int]:
     Generate a one-time use login token for passwordless access.
 
     This endpoint must be called from an already authenticated session.
-    It creates a new session token and returns a shareable login URL.
+    It creates a new session token and returns it with a shareable login URL.
 
     Returns:
-        JSON response with 'login_url' and 'expires_in' fields.
+        JSON response with 'token', 'login_url', and 'expires_in' fields.
     """
     # Check that caller has a valid session (already authenticated)
     auth_token = request.cookies.get(COOKIE_NAME)
@@ -250,47 +235,36 @@ def create_login_token() -> tuple[dict, int]:
     login_token_val = create_login_token_value(USER)
 
     # Construct the one-time login URL
-    login_url = f"{SERVICE_PREFIX}/dash/auth/login-token#token={login_token_val}"
+    login_url = f"{SERVICE_PREFIX}/dash/auth/login-token?token={login_token_val}"
 
     logger.info("Passwordless login token created for user %s", USER)
 
-    return {"login_url": login_url, "expires_in": SESSION_LIFETIME}, HTTPStatus.OK
+    return {"token": login_token_val, "login_url": login_url, "expires_in": SESSION_LIFETIME}, HTTPStatus.OK
 
 
-@app.route("/login-token", methods=["GET", "POST"])
+@app.route("/login-token")
 def login_token_endpoint() -> Response:
     """
-    Serve the login page or consume a one-time token from a POST body.
+    Consume a one-time login token and establish a session cookie.
 
-    The GET response reads the token from the URL fragment in the browser and
-    submits it as JSON to POST, keeping it out of request URLs and referrers.
+    Query params:
+        token: The one-time use token obtained from /create-login-token.
 
     Returns:
-        Login page for GET, or JSON with a redirect target for POST.
+        Redirect to the dashboard with an authenticated session cookie.
     """
-    if request.method == "GET":
-        resp = make_response(LOGIN_TOKEN_BOOTSTRAP, HTTPStatus.OK)
-        resp.headers["Content-Type"] = "text/html; charset=utf-8"
-        resp.headers["Cache-Control"] = "no-store"
-        resp.headers["Referrer-Policy"] = "no-referrer"
-        return resp
-
-    payload = request.get_json(silent=True)
-    if not isinstance(payload, dict):
-        return make_response({"error": "Invalid JSON payload"}, HTTPStatus.BAD_REQUEST)
-    token = payload.get("token")
-
-    if not isinstance(token, str) or not token:
-        return make_response({"error": "Missing token"}, HTTPStatus.BAD_REQUEST)
+    token = request.args.get("token")
+    if not token:
+        return make_response("Missing token parameter", HTTPStatus.BAD_REQUEST)
 
     if not consume_login_token(token, USER):
         logger.warning("Invalid or expired login token attempted for user %s", USER)
-        return make_response({"error": "Invalid or expired token"}, HTTPStatus.UNAUTHORIZED)
+        return make_response("Invalid or expired token", HTTPStatus.UNAUTHORIZED)
 
     # Create a fresh session for the browser
     new_token = create_session(USER)
 
-    resp = make_response({"redirect_url": f"{SERVICE_PREFIX}/dash/"}, HTTPStatus.OK)
+    resp = make_response(redirect(f"{SERVICE_PREFIX}/dash/"))
     resp.set_cookie(COOKIE_NAME, new_token, path=SERVICE_PREFIX, secure=True, httponly=True, samesite="Lax")
 
     logger.info("Passwordless login successful for user %s", USER)

--- a/dashboard/auth/auth.py
+++ b/dashboard/auth/auth.py
@@ -177,5 +177,69 @@ def oauth_callback() -> tuple[str, int] | Response:
     return resp
 
 
+@app.route("/create-login-token", methods=["POST"])
+def create_login_token() -> tuple[dict, int]:
+    """
+    Generate a one-time use login token for passwordless access.
+
+    This endpoint must be called from an already authenticated session.
+    It creates a new session token and returns it so the client can construct
+    a shareable login URL.
+
+    Returns:
+        JSON response with 'token' and 'login_url' fields.
+    """
+    # Check that caller has a valid session (already authenticated)
+    auth_token = request.cookies.get(COOKIE_NAME)
+    if not auth_token or not is_valid_session(auth_token, USER):
+        return {"error": "Authentication required"}, HTTPStatus.UNAUTHORIZED
+
+    # Create a new session token for passwordless access
+    login_token_val = create_session(USER)
+
+    # Construct the one-time login URL
+    login_url = f"{SERVICE_PREFIX}/dash/auth/login-token?token={login_token_val}"
+
+    logger.info("Passwordless login token created for user %s", USER)
+
+    return {"token": login_token_val, "login_url": login_url, "expires_in": SESSION_LIFETIME}, HTTPStatus.OK
+
+
+@app.route("/login-token")
+def login_token_endpoint() -> Response:
+    """
+    Consume a one-time login token and establish a session cookie.
+
+    Query params:
+        token: The one-time use token obtained from /create-login-token
+
+    Returns:
+        Redirect to dashboard home with mddash-auth cookie set, or error response.
+    """
+    token = request.args.get("token")
+
+    if not token:
+        return make_response("Missing token parameter", HTTPStatus.BAD_REQUEST)
+
+    # Validate the token exists and belongs to this user
+    if not is_valid_session(token, USER):
+        logger.warning("Invalid or expired login token attempted for user %s", USER)
+        return make_response("Invalid or expired token", HTTPStatus.UNAUTHORIZED)
+
+    # Token is valid - consume it (one-time use) and set cookie
+    # Remove from session store to prevent reuse
+    if token in _sessions:
+        del _sessions[token]
+
+    # Create a fresh session for the browser
+    new_token = create_session(USER)
+
+    resp = make_response(redirect(f"{SERVICE_PREFIX}/dash/"))
+    resp.set_cookie(COOKIE_NAME, new_token, path=SERVICE_PREFIX, httponly=True, samesite="Lax")
+
+    logger.info("Passwordless login successful for user %s", USER)
+    return resp
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5001)

--- a/dashboard/auth/auth.py
+++ b/dashboard/auth/auth.py
@@ -228,8 +228,7 @@ def login_token_endpoint() -> Response:
 
     # Token is valid - consume it (one-time use) and set cookie
     # Remove from session store to prevent reuse
-    if token in _sessions:
-        del _sessions[token]
+    _sessions.pop(token, None)
 
     # Create a fresh session for the browser
     new_token = create_session(USER)

--- a/dashboard/auth/auth.py
+++ b/dashboard/auth/auth.py
@@ -47,28 +47,19 @@ SESSION_LIFETIME = 3600  # 1 hour
 _last_cleanup = time.time()
 CLEANUP_INTERVAL = 300  # 5 minutes
 
-LOGIN_TOKEN_PAGE = """<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>MDDash login</title></head>
-<body><p id="status">Signing in...</p><script>
-const status = document.getElementById("status");
+LOGIN_TOKEN_BOOTSTRAP = """<script>
 const token = new URLSearchParams(window.location.hash.slice(1)).get("token");
 window.history.replaceState(null, "", window.location.pathname);
-if (!token) {
-  status.textContent = "Invalid login link.";
-} else {
-  fetch(window.location.pathname, {
-    method: "POST",
-    headers: {"Content-Type": "application/json"},
-    body: JSON.stringify({token})
-  }).then(async response => {
-    const result = await response.json();
-    if (!response.ok) throw new Error(result.error || "Login failed.");
-    window.location.replace(result.redirect_url);
-  }).catch(error => { status.textContent = error.message; });
-}
-</script></body>
-</html>"""
+fetch(window.location.pathname, {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({token})
+}).then(async response => {
+  const result = await response.json();
+  if (!response.ok) throw new Error(result.error || "Login failed.");
+  window.location.replace(result.redirect_url);
+}).catch(error => { document.body.textContent = error.message; });
+</script>"""
 
 
 def remove_expired_sessions() -> None:
@@ -278,7 +269,7 @@ def login_token_endpoint() -> Response:
         Login page for GET, or JSON with a redirect target for POST.
     """
     if request.method == "GET":
-        resp = make_response(LOGIN_TOKEN_PAGE, HTTPStatus.OK)
+        resp = make_response(LOGIN_TOKEN_BOOTSTRAP, HTTPStatus.OK)
         resp.headers["Content-Type"] = "text/html; charset=utf-8"
         resp.headers["Cache-Control"] = "no-store"
         resp.headers["Referrer-Policy"] = "no-referrer"

--- a/dashboard/auth/tests/conftest.py
+++ b/dashboard/auth/tests/conftest.py
@@ -28,7 +28,7 @@ os.environ["JUPYTERHUB_DEFAULT_URL"] = "/lab"
 os.environ["JUPYTERHUB_SERVICE_PREFIX"] = "/user/testuser"
 
 # Import after environment is set to prevent validation errors at import time
-from auth import _sessions  # ruff:ignore[import-private-name]
+from auth import _login_tokens, _sessions  # ruff:ignore[import-private-name]
 from auth import app as auth_app
 
 
@@ -59,5 +59,7 @@ def client(app: Flask) -> FlaskClient:
 def clear_sessions() -> Generator[None, None, None]:
     """Clear session store before and after each test."""
     _sessions.clear()
+    _login_tokens.clear()
     yield
     _sessions.clear()
+    _login_tokens.clear()

--- a/dashboard/auth/tests/test_auth.py
+++ b/dashboard/auth/tests/test_auth.py
@@ -8,7 +8,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
-from urllib.parse import parse_qs, urlsplit
 
 import auth
 import pytest
@@ -219,16 +218,15 @@ class TestLoginTokenEndpoints:
         Create a login token through the authenticated endpoint.
 
         Returns:
-            str: The token extracted from the generated URL fragment.
+            str: The generated one-time token.
         """
         auth_token = create_session(USER)
         client.set_cookie(COOKIE_NAME, auth_token)
         response = client.post("/create-login-token")
-        fragment = urlsplit(response.get_json()["login_url"]).fragment
-        return parse_qs(fragment)["token"][0]
+        return response.get_json()["token"]
 
-    def test_create_login_token_keeps_token_out_of_url_query(self, client: FlaskClient) -> None:
-        """Generated login URLs should carry the token only in the fragment."""
+    def test_create_login_token_matches_dispatcher_contract(self, client: FlaskClient) -> None:
+        """Token responses should match the Dispatcher integration contract."""
         auth_token = create_session(USER)
         client.set_cookie(COOKIE_NAME, auth_token)
 
@@ -237,41 +235,40 @@ class TestLoginTokenEndpoints:
         assert response.status_code == HTTPStatus.OK
         payload = response.get_json()
         assert payload is not None
-        assert "token" not in payload
-        assert payload["login_url"].startswith(f"/user/{USER}/dash/auth/login-token#token=")
-        assert "?token=" not in payload["login_url"]
+        assert isinstance(payload["token"], str)
+        assert payload["login_url"] == f"/user/{USER}/dash/auth/login-token?token={payload['token']}"
 
-    def test_get_login_token_does_not_consume_token(self, client: FlaskClient) -> None:
-        """Loading the redemption page should not mutate token state."""
+    def test_get_login_token_consumes_token_and_redirects(self, client: FlaskClient) -> None:
+        """Dispatcher login links should establish a session and redirect."""
         token = self.create_login_token(client)
 
         response = client.get(f"/login-token?token={token}")
 
-        assert response.status_code == HTTPStatus.OK
-        assert COOKIE_NAME not in response.headers.get("Set-Cookie", "")
-        assert client.post("/login-token", json={"token": token}).status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.location == f"/user/{USER}/dash/"
+        assert client.get(f"/login-token?token={token}").status_code == HTTPStatus.UNAUTHORIZED
 
-    def test_post_login_token_consumes_token_once(self, app: Flask) -> None:
+    def test_get_login_token_consumes_token_once(self, app: Flask) -> None:
         """Concurrent redemption attempts should produce only one session."""
         with app.test_client() as client:
             token = self.create_login_token(client)
 
         def redeem() -> int:
             with app.test_client() as client:
-                return client.post("/login-token", json={"token": token}).status_code
+                return client.get(f"/login-token?token={token}").status_code
 
         with ThreadPoolExecutor(max_workers=2) as executor:
             statuses = sorted(executor.map(lambda _: redeem(), range(2)))
 
-        assert statuses == [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED]
+        assert statuses == [HTTPStatus.FOUND, HTTPStatus.UNAUTHORIZED]
 
     def test_redeemed_session_cookie_is_secure(self, client: FlaskClient) -> None:
         """Passwordless sessions should use hardened cookie attributes."""
         token = self.create_login_token(client)
 
-        response = client.post("/login-token", json={"token": token})
+        response = client.get(f"/login-token?token={token}")
 
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.FOUND
         set_cookie = response.headers["Set-Cookie"]
         assert "Secure" in set_cookie
         assert "HttpOnly" in set_cookie
@@ -286,16 +283,9 @@ class TestLoginTokenEndpoints:
 
         assert response.status_code == HTTPStatus.FOUND
 
-    def test_login_token_rejects_oversized_body(self, client: FlaskClient) -> None:
-        """The public redemption endpoint should bound request memory usage."""
-        response = client.post("/login-token", json={"token": "x" * 4097})
-
-        assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-
-    @pytest.mark.parametrize("payload", [["token"], "token", True])
-    def test_login_token_rejects_non_object_json(self, client: FlaskClient, payload: object) -> None:
-        """Malformed JSON shapes should receive a controlled client error."""
-        response = client.post("/login-token", json=payload)
+    def test_login_token_requires_token_query_parameter(self, client: FlaskClient) -> None:
+        """Redemption should reject requests without a token."""
+        response = client.get("/login-token")
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
 

--- a/dashboard/auth/tests/test_auth.py
+++ b/dashboard/auth/tests/test_auth.py
@@ -5,12 +5,15 @@ Tests session management, HMAC signing, and OAuth flow.
 """
 
 import time
+from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 import auth
 import pytest
 from auth import (
+    COOKIE_NAME,
     HMAC_SHA256_HEX_LENGTH,
     STATE_COOKIE,
     USER,
@@ -204,6 +207,97 @@ class TestOAuthCallback:
         returned_user = "wronguser"
 
         assert expected_user != returned_user
+
+
+@pytest.mark.usefixtures("clear_sessions")
+class TestLoginTokenEndpoints:
+    """Tests for passwordless login token creation and redemption."""
+
+    @staticmethod
+    def create_login_token(client: FlaskClient) -> str:
+        """
+        Create a login token through the authenticated endpoint.
+
+        Returns:
+            str: The token extracted from the generated URL fragment.
+        """
+        auth_token = create_session(USER)
+        client.set_cookie(COOKIE_NAME, auth_token)
+        response = client.post("/create-login-token")
+        fragment = urlsplit(response.get_json()["login_url"]).fragment
+        return parse_qs(fragment)["token"][0]
+
+    def test_create_login_token_keeps_token_out_of_url_query(self, client: FlaskClient) -> None:
+        """Generated login URLs should carry the token only in the fragment."""
+        auth_token = create_session(USER)
+        client.set_cookie(COOKIE_NAME, auth_token)
+
+        response = client.post("/create-login-token")
+
+        assert response.status_code == HTTPStatus.OK
+        payload = response.get_json()
+        assert payload is not None
+        assert "token" not in payload
+        assert payload["login_url"].startswith(f"/user/{USER}/dash/auth/login-token#token=")
+        assert "?token=" not in payload["login_url"]
+
+    def test_get_login_token_does_not_consume_token(self, client: FlaskClient) -> None:
+        """Loading the redemption page should not mutate token state."""
+        token = self.create_login_token(client)
+
+        response = client.get(f"/login-token?token={token}")
+
+        assert response.status_code == HTTPStatus.OK
+        assert COOKIE_NAME not in response.headers.get("Set-Cookie", "")
+        assert client.post("/login-token", json={"token": token}).status_code == HTTPStatus.OK
+
+    def test_post_login_token_consumes_token_once(self, app: Flask) -> None:
+        """Concurrent redemption attempts should produce only one session."""
+        with app.test_client() as client:
+            token = self.create_login_token(client)
+
+        def redeem() -> int:
+            with app.test_client() as client:
+                return client.post("/login-token", json={"token": token}).status_code
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            statuses = sorted(executor.map(lambda _: redeem(), range(2)))
+
+        assert statuses == [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED]
+
+    def test_redeemed_session_cookie_is_secure(self, client: FlaskClient) -> None:
+        """Passwordless sessions should use hardened cookie attributes."""
+        token = self.create_login_token(client)
+
+        response = client.post("/login-token", json={"token": token})
+
+        assert response.status_code == HTTPStatus.OK
+        set_cookie = response.headers["Set-Cookie"]
+        assert "Secure" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=Lax" in set_cookie
+
+    def test_login_token_is_not_accepted_as_session_cookie(self, client: FlaskClient) -> None:
+        """One-time login credentials should not authenticate as sessions."""
+        token = self.create_login_token(client)
+        client.set_cookie(COOKIE_NAME, token)
+
+        response = client.get("/auth")
+
+        assert response.status_code == HTTPStatus.FOUND
+
+    def test_login_token_rejects_oversized_body(self, client: FlaskClient) -> None:
+        """The public redemption endpoint should bound request memory usage."""
+        response = client.post("/login-token", json={"token": "x" * 4097})
+
+        assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+
+    @pytest.mark.parametrize("payload", [["token"], "token", True])
+    def test_login_token_rejects_non_object_json(self, client: FlaskClient, payload: object) -> None:
+        """Malformed JSON shapes should receive a controlled client error."""
+        response = client.post("/login-token", json=payload)
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_health_logs_first_health_once(client: FlaskClient, caplog) -> None:  # ruff:ignore[missing-type-function-argument]

--- a/dashboard/proxy/Caddyfile
+++ b/dashboard/proxy/Caddyfile
@@ -34,6 +34,17 @@ http://:8888 {
 		}
 	}
 
+	# Auth service routes (passwordless login) - proxied to auth container without forward_auth
+	@auth_routes {
+		path {$CADDY_ROUTE_PREFIX}/dash/auth/*login-token*
+	}
+	handle @auth_routes {
+		uri strip_prefix {$CADDY_ROUTE_PREFIX}
+		reverse_proxy {$AUTH_HOST}:5001 {
+			lb_try_duration 5s
+		}
+	}
+
 	# API routes - authenticated via forward_auth to auth container
 	@api_routes {
 		path_regexp ^{$CADDY_ROUTE_PREFIX}/dash/api.*$

--- a/dashboard/proxy/Caddyfile
+++ b/dashboard/proxy/Caddyfile
@@ -39,7 +39,7 @@ http://:8888 {
 		path {$CADDY_ROUTE_PREFIX}/dash/auth/*login-token*
 	}
 	handle @auth_routes {
-		uri strip_prefix {$CADDY_ROUTE_PREFIX}
+		uri strip_prefix {$CADDY_ROUTE_PREFIX}/dash/auth
 		reverse_proxy {$AUTH_HOST}:5001 {
 			lb_try_duration 5s
 		}

--- a/dashboard/proxy/Caddyfile
+++ b/dashboard/proxy/Caddyfile
@@ -36,7 +36,8 @@ http://:8888 {
 
 	# Auth service routes (passwordless login) - proxied to auth container without forward_auth
 	@auth_routes {
-		path {$CADDY_ROUTE_PREFIX}/dash/auth/*login-token*
+		path {$CADDY_ROUTE_PREFIX}/dash/auth/create-login-token
+		path {$CADDY_ROUTE_PREFIX}/dash/auth/login-token
 	}
 	handle @auth_routes {
 		uri strip_prefix {$CADDY_ROUTE_PREFIX}/dash/auth

--- a/scripts/jwt_create_experiment.py
+++ b/scripts/jwt_create_experiment.py
@@ -7,8 +7,16 @@ A standalone manual test script that:
 2. Waits for the singleuser server to be ready,
 3. Completes the OAuth flow for mddash session,
 4. Creates a molecular dynamics experiment (PDB: 1L2Y) via the dashboard API.
+5. Generates a passwordless login URL by requesting a token from the auth service.
 
 Requires a `TOKEN` environment variable containing a valid EGI JWT access token.
+
+Usage:
+    TOKEN=<jwt-token> python scripts/jwt_create_experiment.py
+
+Output:
+    - Experiment creation result
+    - Passwordless login URL that can be shared for direct access
 """
 
 import json
@@ -46,7 +54,7 @@ def create_experiment():
         print("Error: TOKEN environment variable missing.")
         return
 
-    base_url = "https://mddash-edc.dyn.cloud.e-infra.cz"
+    base_url = "https://mddash-edc-dev.dyn.cloud.e-infra.cz"
     login_url = f"{base_url}/hub/jwt_login"
     user_api_url = f"{base_url}/hub/api/user"
 
@@ -54,6 +62,9 @@ def create_experiment():
     EXPERIMENT_NAME = "test-experiment-1L2Y"
     PDB_ID = "1L2Y"
     NOTEBOOKS_REPO = "https://github.com/sb-ncbr/mddash-notebooks.git"
+
+    # Passwordless access configuration
+    GENERATE_PASSWORDLESS_URL = True  # Set to False to skip passwordless URL generation
 
     session = requests.Session()
 
@@ -180,6 +191,40 @@ def create_experiment():
             print(f"Experiment ID: {exp_id}")
     else:
         print(f"\nFailed to create experiment. Status: {resp.status_code}")
+
+    # Step 7: Request passwordless login URL from auth service
+    if GENERATE_PASSWORDLESS_URL:
+        print("--- Step 7: Requesting passwordless login URL ---")
+
+        # Call the /create-login-token endpoint which:
+        # 1. Validates the existing mddash-auth cookie
+        # 2. Creates a new session token server-side
+        # 3. Returns the token so we can construct the login URL
+        create_token_url = f"{base_url}{server_url_path}dash/auth/create-login-token"
+
+        log_request("POST", create_token_url)
+        resp = session.post(create_token_url)
+        log_response(resp, "CREATE_LOGIN_TOKEN")
+
+        if resp.status_code == 200:
+            result = resp.json()
+            login_token = result.get("token")
+            login_url = result.get("login_url")
+            expires_in = result.get("expires_in", 3600)
+
+            print("\n" + "=" * 60)
+            print("PASSWORDLESS LOGIN URL:")
+            print("=" * 60)
+            print(login_url)
+            print("=" * 60)
+            print(f"\nThis token is valid for {expires_in // 60} minutes.")
+            print("The token is one-time use: consuming it will invalidate it.")
+            print()
+        else:
+            print(f"\nFailed to generate passwordless URL. Status: {resp.status_code}")
+            error_detail = resp.json().get("error", resp.text) if resp.content else "Unknown error"
+            print(f"Error: {error_detail}")
+            print()
 
 
 if __name__ == "__main__":

--- a/scripts/jwt_create_experiment.py
+++ b/scripts/jwt_create_experiment.py
@@ -54,7 +54,7 @@ def create_experiment():
         print("Error: TOKEN environment variable missing.")
         return
 
-    base_url = "https://mddash-edc-dev.dyn.cloud.e-infra.cz"
+    base_url = "https://mddash-edc.dyn.cloud.e-infra.cz"
     login_url = f"{base_url}/hub/jwt_login"
     user_api_url = f"{base_url}/hub/api/user"
 
@@ -208,7 +208,6 @@ def create_experiment():
 
         if resp.status_code == 200:
             result = resp.json()
-            login_token = result.get("token")
             login_url = result.get("login_url")
             expires_in = result.get("expires_in", 3600)
 


### PR DESCRIPTION
Provide two misc auth endpoints:
- /create-login-token requires authenticated session, generates a one-time token
- /login-token consumes the token without previous authentication, and creates an authenticated session

The expected use is in EOSC Data Commons; its services prepare MDDash experiment on the user's behalf; the user needn't authenticate again to follow the prepared link.

This is MDDash side of implementing https://github.com/EOSC-Data-Commons/Dispatcher/issues/140 

--
(c) vibecoded by Claude using Qwen3.5, verified by @ljocha 