### PR TITLE
feat(experiments): initialize experiment from PDB ID or direct URL

### DIFF
--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -75,6 +75,27 @@ def _fetch_pdb(url: str, *, max_redirects: int = 5) -> requests.Response:
     raise InternalServerError(description="Too many redirects while downloading PDB file.")
 
 
+_PDB_STRUCTURE_RECORDS = {"ATOM", "HETATM"}
+
+
+def _validate_pdb_content(content: bytes) -> None:
+    """
+    Reject downloaded content that is not a PDB structure file.
+
+    PDB record types occupy columns 1-6 of each line; a structural PDB file
+    must contain at least one ATOM or HETATM record. This catches HTML error
+    pages, login redirects, and binary responses that nonetheless return 200.
+
+    Raises:
+        BadRequest: If no ATOM/HETATM record is present.
+    """
+    text = content.decode("utf-8", errors="replace")
+    for line in text.splitlines():
+        if line[:6].strip() in _PDB_STRUCTURE_RECORDS:
+            return
+    raise BadRequest(description="Downloaded content is not a valid PDB file (no ATOM or HETATM records).")
+
+
 _SCHEMA_FILES = ("gromacs.schema.json", "amber.schema.json")
 
 
@@ -346,6 +367,8 @@ class Experiment(db.Model):  # type: ignore
                 raise NotFound(description=f"PDB source '{source}' not found.")
             if response.status_code != HTTPStatus.OK:
                 raise InternalServerError(description=f"Failed to download PDB file: {response.status_code}")
+
+            _validate_pdb_content(response.content)
 
             with (DATA_DIR / experiment_id / "input.pdb").open("wb") as f:
                 f.write(response.content)

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 from pathlib import Path
 from shutil import move, rmtree
 from typing import TYPE_CHECKING
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import requests
 import yaml
@@ -21,6 +21,7 @@ from flask import session
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from token_manager import MDRepoTokenManager
 from utils import download_git_repo, get_unique_id
+from validators import validate_fetch_target, validate_http_url
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 from werkzeug.utils import secure_filename
@@ -47,6 +48,31 @@ def _list_simulations(experiment_id: str) -> list["Simulation"]:
     from .simulation import Simulation  # ruff:ignore[import-outside-top-level]
 
     return Simulation.list(experiment_id)
+
+
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+def _fetch_pdb(url: str, *, max_redirects: int = 5) -> requests.Response:
+    """
+    Fetch a PDB URL without auto-following redirects; each hop is SSRF-validated.
+
+    Returns:
+        The final non-redirect response.
+
+    Raises:
+        InternalServerError: If the redirect chain exceeds max_redirects.
+    """
+    for _ in range(max_redirects + 1):
+        validate_fetch_target(url)
+        response = requests.get(url, timeout=30, allow_redirects=False)
+        if response.status_code not in _REDIRECT_STATUSES:
+            return response
+        location = response.headers.get("Location")
+        if not location:
+            return response
+        url = validate_http_url(urljoin(url, location))
+    raise InternalServerError(description="Too many redirects while downloading PDB file.")
 
 
 _SCHEMA_FILES = ("gromacs.schema.json", "amber.schema.json")
@@ -273,17 +299,22 @@ class Experiment(db.Model):  # type: ignore
     def from_pdb(
         cls,
         name: str,
-        pdb_id: str,
+        pdb_source: str,
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
     ) -> "Experiment":
         """
-        Create experiment from PDB ID with database persistence.
+        Create experiment from a PDB ID or a direct URL to a PDB file.
+
+        A value without a URL scheme (e.g. ``1A2B``) is treated as an RCSB PDB ID
+        and downloaded from ``files.rcsb.org``. A value with a URL scheme (e.g.
+        ``https://...``) is treated as a direct URL to a PDB file and fetched
+        as-is; only ``http`` and ``https`` schemes are accepted.
 
         Args:
             name: Name of the experiment.
-            pdb_id: PDB ID to download (e.g., 1A2B).
+            pdb_source: PDB ID (e.g., 1A2B) or a direct URL to a PDB file.
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional GitHub access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
@@ -292,26 +323,33 @@ class Experiment(db.Model):  # type: ignore
             The created Experiment instance.
 
         Raises:
-            NotFound: If the PDB ID is not found.
+            NotFound: If the PDB ID or URL is not found.
             InternalServerError: If the PDB file download fails.
         """
         experiment_id: str = cls.prepare_env(notebooks_repo, access_token)
-        pdb_id = pdb_id.strip().upper()
+        source = pdb_source.strip()
+        is_url = bool(urlparse(source).scheme)
 
         try:
+            if is_url:
+                url: str = validate_http_url(source)
+                message: str = f"Created by downloading PDB file from '{source}'."
+            else:
+                pdb_id = source.upper()
+                url = f"https://files.rcsb.org/download/{pdb_id}.pdb"
+                message = f"Created by downloading '{pdb_id}' from RCSB PDB."
+
             # Download PDB file
-            url: str = f"https://files.rcsb.org/download/{pdb_id}.pdb"
-            response = requests.get(url, timeout=30)
+            response = _fetch_pdb(url)
 
             if response.status_code == HTTPStatus.NOT_FOUND:
-                raise NotFound(description=f"PDB ID '{pdb_id}' not found.")
+                raise NotFound(description=f"PDB source '{source}' not found.")
             if response.status_code != HTTPStatus.OK:
                 raise InternalServerError(description=f"Failed to download PDB file: {response.status_code}")
 
             with (DATA_DIR / experiment_id / "input.pdb").open("wb") as f:
                 f.write(response.content)
 
-            message: str = f"Created by downloading '{pdb_id}' from RCSB PDB."
             experiment = cls(
                 id=experiment_id, name=name, source_message=message, notebooks_repo=notebooks_repo, engine=engine
             )

--- a/dashboard/api/routes/experiments.py
+++ b/dashboard/api/routes/experiments.py
@@ -45,7 +45,7 @@ def create_experiment() -> ResponseReturnValue:
     form = request.form
 
     name = form["experiment-name"]
-    pdb_id = form.get("pdb-id")
+    pdb_source = form.get("pdb")
     repo_url = form.get("repo-url")
     notebooks_repo = form.get("notebooks-repo", DEFAULT_NOTEBOOKS_REPO)
     access_token = form.get("access-token")
@@ -61,8 +61,8 @@ def create_experiment() -> ResponseReturnValue:
     validate_git_url(notebooks_repo)
 
     match form["type"]:
-        case "pdb" if pdb_id:
-            experiment = Experiment.from_pdb(name, pdb_id, notebooks_repo, access_token, engine=engine)
+        case "pdb" if pdb_source:
+            experiment = Experiment.from_pdb(name, pdb_source, notebooks_repo, access_token, engine=engine)
         case "repo" if repo_url:
             experiment = Experiment.from_repo(name, repo_url, notebooks_repo, access_token, engine=engine)
         case "file" if simulation_files:

--- a/dashboard/api/tests/integration/test_experiments.py
+++ b/dashboard/api/tests/integration/test_experiments.py
@@ -106,7 +106,7 @@ class TestCreateExperiment:
                 data={
                     "type": "pdb",
                     "experiment-name": "Test PDB Experiment",
-                    "pdb-id": "1ABC",
+                    "pdb": "1ABC",
                     "notebooks-repo": "https://github.com/test/repo.git",
                 },
             )
@@ -134,12 +134,160 @@ class TestCreateExperiment:
                 data={
                     "type": "pdb",
                     "experiment-name": "Invalid PDB",
-                    "pdb-id": "XXXX",
+                    "pdb": "XXXX",
                     "notebooks-repo": "https://github.com/test/repo.git",
                 },
             )
 
             assert response.status_code == HTTPStatus.NOT_FOUND
+
+    def test_create_from_pdb_url_success(self, client: FlaskClient, sample_pdb_content: bytes, tmp_path: Path) -> None:
+        """Should create experiment from a direct URL to a PDB file."""
+        pdb_url = "https://www.ebi.ac.uk/pdbe/entry-files/download/pdb3vte.ent"
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_clone,
+            patch("validators._getaddrinfo_ips", return_value=["193.62.193.80"]),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = sample_pdb_content
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "PDB URL Experiment",
+                    "pdb": pdb_url,
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.CREATED
+            data = json.loads(response.data)
+            assert data["name"] == "PDB URL Experiment"
+            assert pdb_url in data["source_message"]
+            assert len(data["id"]) == EXPERIMENT_ID_LENGTH
+            # The URL should be fetched directly, not the RCSB ID URL
+            mock_get.assert_called_once_with(pdb_url, timeout=30, allow_redirects=False)
+            mock_clone.assert_called_once()
+
+    def test_create_from_pdb_url_not_found(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 404 when a PDB URL returns 404."""
+        pdb_url = "https://example.org/missing.pdb"
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+            patch("validators._getaddrinfo_ips", return_value=["93.184.216.34"]),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Missing URL",
+                    "pdb": pdb_url,
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.NOT_FOUND
+
+    def test_create_from_pdb_url_rejects_file_scheme(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 400 when a PDB URL uses a non-http(s) scheme."""
+        with (
+            patch("models.experiment.requests.get"),
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+        ):
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Bad Scheme",
+                    "pdb": "file:///etc/passwd",
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_create_from_pdb_url_rejects_internal_host(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 400 when a PDB URL points at an internal SSRF target."""
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+        ):
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "SSRF Attempt",
+                    "pdb": "http://169.254.169.254/latest/meta-data/",
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            mock_get.assert_not_called()
+
+    def test_create_from_pdb_url_rejects_hostname_resolving_internal(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 400 when a PDB URL hostname resolves to an internal IP."""
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+            patch("validators._getaddrinfo_ips", return_value=["10.43.0.1"]),
+        ):
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "SSRF Hostname",
+                    "pdb": "https://kubernetes.default.svc/api",
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            mock_get.assert_not_called()
+
+    def test_create_from_pdb_url_rejects_redirect_to_internal(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should reject a redirect chain that lands on an internal target."""
+        external_url = "https://example.org/pdb3vte.ent"
+        internal_url = "http://169.254.169.254/latest/meta-data/"
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+            patch("validators._getaddrinfo_ips", return_value=["93.184.216.34"]),
+        ):
+            redirect_resp = MagicMock()
+            redirect_resp.status_code = 302
+            redirect_resp.headers = {"Location": internal_url}
+
+            mock_get.side_effect = [redirect_resp]
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Redirect SSRF",
+                    "pdb": external_url,
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            # Only the first (external) hop should have been fetched.
+            mock_get.assert_called_once_with(external_url, timeout=30, allow_redirects=False)
 
     def test_create_uses_default_notebooks_repo(
         self, client: FlaskClient, sample_pdb_content: bytes, tmp_path: Path
@@ -161,7 +309,7 @@ class TestCreateExperiment:
                 data={
                     "type": "pdb",
                     "experiment-name": "Test Default Repo",
-                    "pdb-id": "1ABC",
+                    "pdb": "1ABC",
                     # No notebooks-repo provided - should use default
                 },
             )
@@ -190,7 +338,7 @@ class TestCreateExperiment:
                 data={
                     "type": "pdb",
                     "experiment-name": "Clone Fail Test",
-                    "pdb-id": "1ABC",
+                    "pdb": "1ABC",
                     "notebooks-repo": "https://github.com/test/repo.git",
                 },
             )
@@ -204,7 +352,7 @@ class TestCreateExperiment:
             data={
                 "type": "pdb",
                 "experiment-name": "Invalid URL Test",
-                "pdb-id": "1ABC",
+                "pdb": "1ABC",
                 "notebooks-repo": "file:///etc/passwd",
             },
         )

--- a/dashboard/api/tests/integration/test_experiments.py
+++ b/dashboard/api/tests/integration/test_experiments.py
@@ -174,6 +174,62 @@ class TestCreateExperiment:
             mock_get.assert_called_once_with(pdb_url, timeout=30, allow_redirects=False)
             mock_clone.assert_called_once()
 
+    def test_create_from_pdb_url_rejects_html_response(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 400 when a PDB URL returns HTML instead of a PDB file."""
+        pdb_url = "https://example.org/login"
+        html_content = b"<!DOCTYPE html><html><body>Please log in</body></html>"
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+            patch("validators._getaddrinfo_ips", return_value=["93.184.216.34"]),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = html_content
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "HTML Response",
+                    "pdb": pdb_url,
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            # The invalid content must not be persisted as input.pdb
+            assert not any((tmp_path / d / "input.pdb").exists() for d in tmp_path.iterdir() if d.is_dir())
+
+    def test_create_from_pdb_id_rejects_non_pdb_response(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Should return 400 when an RCSB PDB ID returns non-PDB content."""
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo"),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b"<html><body>not a pdb</body></html>"
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Bad RCSB",
+                    "pdb": "1ABC",
+                    "notebooks-repo": "https://github.com/test/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            mock_get.assert_called_once_with(
+                "https://files.rcsb.org/download/1ABC.pdb", timeout=30, allow_redirects=False
+            )
+
     def test_create_from_pdb_url_not_found(self, client: FlaskClient, tmp_path: Path) -> None:
         """Should return 404 when a PDB URL returns 404."""
         pdb_url = "https://example.org/missing.pdb"

--- a/dashboard/api/tests/unit/test_validators.py
+++ b/dashboard/api/tests/unit/test_validators.py
@@ -1,6 +1,7 @@
 """Unit tests for input validators."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from enums import AnalysisType, PreprocessingMode
@@ -11,7 +12,9 @@ from validators import (
     check_path,
     check_positive_int,
     validate_analysis_topology_path,
+    validate_fetch_target,
     validate_git_url,
+    validate_http_url,
 )
 from werkzeug.exceptions import BadRequest, Forbidden
 
@@ -330,3 +333,122 @@ class TestValidateGitUrl:
         """Unsupported protocol ftp:// should be rejected."""
         with pytest.raises(BadRequest):
             validate_git_url("ftp://server.com/repo.git")
+
+
+class TestValidateHttpUrl:
+    """Tests for the validate_http_url function."""
+
+    def test_accepts_https_url(self) -> None:
+        """Valid HTTPS URL should be accepted and returned."""
+        url = "https://www.ebi.ac.uk/pdbe/entry-files/download/pdb3vte.ent"
+        assert validate_http_url(url) == url
+
+    def test_accepts_http_url(self) -> None:
+        """Valid HTTP URL should be accepted."""
+        assert validate_http_url("http://example.org/file.pdb") == "http://example.org/file.pdb"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        """Leading/trailing whitespace should be stripped before validation."""
+        url = "https://example.org/file.pdb"
+        assert validate_http_url(f"  {url}  ") == url
+
+    def test_rejects_empty_url(self) -> None:
+        """Empty URL should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("")
+
+    def test_rejects_whitespace_only(self) -> None:
+        """Whitespace-only URL should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("   ")
+
+    def test_rejects_file_protocol(self) -> None:
+        """file:// URL should be rejected to prevent local file access."""
+        with pytest.raises(BadRequest):
+            validate_http_url("file:///etc/passwd")
+
+    def test_rejects_ftp_protocol(self) -> None:
+        """Unsupported protocol ftp:// should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("ftp://server.com/file.pdb")
+
+    def test_rejects_url_with_credentials(self) -> None:
+        """URL with embedded credentials should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("https://user:password@example.org/file.pdb")
+
+    def test_rejects_url_with_username_only(self) -> None:
+        """URL with embedded username should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("https://user@example.org/file.pdb")
+
+    def test_rejects_missing_host(self) -> None:
+        """URL without a host should be rejected."""
+        with pytest.raises(BadRequest):
+            validate_http_url("https:///file.pdb")
+
+    def test_accepts_internal_literal_ip_at_format_level(self) -> None:
+        """Format validation does not inspect IPs; reserved IPs are handled by validate_fetch_target."""
+        validate_http_url("http://127.0.0.1/file.pdb")  # Should not raise
+
+
+class TestValidateFetchTarget:
+    """Tests for the SSRF guard (reserved/internal IP rejection)."""
+
+    def test_rejects_loopback_literal_ip(self) -> None:
+        """Loopback IP targets must be rejected."""
+        with pytest.raises(BadRequest):
+            validate_fetch_target("http://127.0.0.1/file.pdb")
+
+    def test_rejects_ipv6_loopback(self) -> None:
+        """IPv6 loopback must be rejected."""
+        with pytest.raises(BadRequest):
+            validate_fetch_target("http://[::1]/file.pdb")
+
+    def test_rejects_private_literal_ip(self) -> None:
+        """RFC1918 private ranges must be rejected."""
+        with pytest.raises(BadRequest):
+            validate_fetch_target("http://10.0.0.1/file.pdb")
+
+    def test_rejects_link_local_metadata_ip(self) -> None:
+        """Cloud metadata endpoint (169.254.169.254) must be rejected."""
+        with pytest.raises(BadRequest):
+            validate_fetch_target("http://169.254.169.254/latest/meta-data/")
+
+    def test_accepts_public_literal_ip(self) -> None:
+        """A public literal IP should be accepted."""
+        validate_fetch_target("http://8.8.8.8/file.pdb")  # Should not raise
+
+    def test_accepts_literal_ip_with_port(self) -> None:
+        """A public literal IP with an explicit port should be accepted."""
+        validate_fetch_target("http://8.8.8.8:8080/file.pdb")  # Should not raise
+
+    def test_rejects_hostname_resolving_to_loopback(self) -> None:
+        """A hostname resolving to a loopback IP must be rejected."""
+        with patch("validators._getaddrinfo_ips", return_value=["127.0.0.1"]), pytest.raises(BadRequest):
+            validate_fetch_target("http://localhost/file.pdb")
+
+    def test_rejects_hostname_resolving_to_private(self) -> None:
+        """A cluster-internal hostname resolving to a private IP must be rejected."""
+        with patch("validators._getaddrinfo_ips", return_value=["10.43.0.1"]), pytest.raises(BadRequest):
+            validate_fetch_target("https://kubernetes.default.svc/api")
+
+    def test_rejects_hostname_resolving_to_metadata(self) -> None:
+        """A hostname resolving to the link-local metadata IP must be rejected."""
+        with patch("validators._getaddrinfo_ips", return_value=["169.254.169.254"]), pytest.raises(BadRequest):
+            validate_fetch_target("http://metadata.google.internal/computeMetadata/v1/")
+
+    def test_rejects_when_any_resolved_ip_is_reserved(self) -> None:
+        """If any resolved IP is reserved, the target must be rejected."""
+        with patch("validators._getaddrinfo_ips", return_value=["8.8.8.8", "10.0.0.1"]), pytest.raises(BadRequest):
+            validate_fetch_target("http://example.org/file.pdb")
+
+    def test_accepts_hostname_resolving_to_public_ip(self) -> None:
+        """A hostname resolving only to public IPs should be accepted."""
+        with patch("validators._getaddrinfo_ips", return_value=["93.184.216.34"]):
+            validate_fetch_target("https://example.org/file.pdb")  # Should not raise
+
+    def test_rejects_unresolvable_host(self) -> None:
+        """A hostname that cannot be resolved should be rejected."""
+        with patch("validators._getaddrinfo_ips", side_effect=BadRequest("nope")), pytest.raises(BadRequest):
+            validate_fetch_target("http://nonexistent.invalid/file.pdb")

--- a/dashboard/api/validators.py
+++ b/dashboard/api/validators.py
@@ -1,6 +1,8 @@
+import ipaddress
 import re
+import socket
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from enums import AnalysisType, PreprocessingMode
 from werkzeug.exceptions import BadRequest, Forbidden
@@ -207,11 +209,109 @@ def validate_git_url(git_url: str) -> None:
     if url.startswith("git@") and ":" in url:
         return
 
-    # HTTPS/HTTP URLs
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        raise BadRequest("Only http://, https://, or git@ URLs are allowed.")
+    _assert_http_url_safe(
+        urlparse(url),
+        allowed_schemes={"http", "https"},
+        scheme_msg="Only http://, https://, or git@ URLs are allowed.",
+        missing_host_msg="Invalid git URL: missing host.",
+    )
+
+
+def _assert_http_url_safe(
+    parsed: ParseResult,
+    *,
+    allowed_schemes: set[str],
+    scheme_msg: str,
+    missing_host_msg: str,
+) -> None:
+    """
+    Shared HTTP(S) safety core: scheme allow-list, no embedded credentials, host present.
+
+    Raises:
+        BadRequest: If the scheme is unsupported, credentials are embedded, or the host is missing.
+    """
+    if parsed.scheme not in allowed_schemes:
+        raise BadRequest(scheme_msg)
     if parsed.username or parsed.password:
         raise BadRequest("URLs with embedded credentials are not allowed.")
     if not parsed.netloc:
-        raise BadRequest("Invalid git URL: missing host.")
+        raise BadRequest(missing_host_msg)
+
+
+def _is_reserved_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """
+    Check whether an IP is loopback, private, link-local, reserved, multicast, or unspecified.
+
+    Returns:
+        True if the IP is internal/reserved and must not be fetched.
+    """
+    return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+
+
+def _getaddrinfo_ips(hostname: str) -> list[str]:
+    """
+    Resolve hostname to deduplicated literal IP strings via getaddrinfo.
+
+    Returns:
+        The deduplicated list of resolved IP strings.
+
+    Raises:
+        BadRequest: If the hostname cannot be resolved.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise BadRequest(f"Could not resolve host '{hostname}': {exc}")
+    seen: list[str] = []
+    for info in infos:
+        ip = str(info[4][0])
+        if ip not in seen:
+            seen.append(ip)
+    return seen
+
+
+def validate_http_url(url: str) -> str:
+    """
+    Validate an HTTP(S) URL for server-side fetching.
+
+    Rejects non-http(s) schemes, embedded credentials, and missing hosts.
+    Reserved-IP checks are handled by :func:`validate_fetch_target`.
+
+    Returns:
+        The validated, normalized URL.
+
+    Raises:
+        BadRequest: If the URL is empty, has an unsupported scheme, embeds credentials, or is missing a host.
+    """
+    if not url or not url.strip():
+        raise BadRequest("URL cannot be empty.")
+
+    parsed = urlparse(url.strip())
+    _assert_http_url_safe(
+        parsed,
+        allowed_schemes={"http", "https"},
+        scheme_msg="Only http:// and https:// URLs are allowed.",
+        missing_host_msg="Invalid URL: missing host.",
+    )
+    return parsed.geturl()
+
+
+def validate_fetch_target(url: str) -> None:
+    """
+    Reject URLs whose host is or resolves to a reserved/internal IP (SSRF guard).
+
+    Literal IPs are checked directly; hostnames are resolved via
+    :func:`_getaddrinfo_ips` and every resolved IP is checked. Targets are
+    matched by resolved address rather than an enumerated hostname list.
+
+    Raises:
+        BadRequest: If the host is or resolves to a reserved/internal IP.
+    """
+    hostname = urlparse(url).hostname or ""
+    try:
+        ips: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        ips = [ipaddress.ip_address(ip) for ip in _getaddrinfo_ips(hostname)]
+
+    if any(_is_reserved_ip(ip) for ip in ips):
+        raise BadRequest("Internal or reserved host targets are not allowed.")

--- a/dashboard/ui/src/pages/New.tsx
+++ b/dashboard/ui/src/pages/New.tsx
@@ -37,7 +37,7 @@ const New = () => {
   const [name, setName] = useState("")
   const [engine, setEngine] = useState<EngineType>(Engine.GMX)
   const [type, setType] = useState("")
-  const [pdbId, setPdbId] = useState("")
+  const [pdb, setPdb] = useState("")
   const [repoUrl, setRepoUrl] = useState("")
   const [files, setFiles] = useState<File[]>([])
   const [notebooksRepo, setNotebooksRepo] = useState(DEFAULT_NOTEBOOKS_REPO)
@@ -64,7 +64,7 @@ const New = () => {
     let auxErr = false
     const notebooksInvalid = !isValidGitUrl(notebooksRepo)
 
-    if ((type === "pdb" && !pdbId) || (type === "repo" && !repoUrl) || (type === "file" && files.length === 0))
+    if ((type === "pdb" && !pdb) || (type === "repo" && !repoUrl) || (type === "file" && files.length === 0))
       auxErr = true
 
     setNameError(!name)
@@ -88,7 +88,7 @@ const New = () => {
     formData.append("engine", engine)
     formData.append("type", type)
     formData.append("notebooks-repo", notebooksRepo)
-    if (type === "pdb") formData.append("pdb-id", pdbId)
+    if (type === "pdb") formData.append("pdb", pdb)
     if (type === "repo") formData.append("repo-url", repoUrl)
     if (type === "file" && files.length > 0) {
       files.forEach((file) => formData.append("simulation-files", file))
@@ -105,7 +105,7 @@ const New = () => {
 
   const handleTypeChange = (newType: string) => {
     setType(newType)
-    setPdbId("")
+    setPdb("")
     setRepoUrl("")
     setFiles([])
   }
@@ -150,7 +150,7 @@ const New = () => {
                     Upload Files
                   </TabsTrigger>
                   <TabsTrigger value="pdb" className="flex-1">
-                    PDB ID
+                    PDB
                   </TabsTrigger>
                   <TabsTrigger value="repo" className="flex-1">
                     DOI / Repository
@@ -164,13 +164,17 @@ const New = () => {
 
             {type === "pdb" && (
               <div className="flex flex-col gap-1">
-                <Label htmlFor="pdb-id">PDB ID</Label>
+                <Label htmlFor="pdb">PDB ID or URL</Label>
                 <Input
-                  id="pdb-id"
-                  value={pdbId}
-                  onChange={(e) => setPdbId(e.target.value)}
+                  id="pdb"
+                  value={pdb}
+                  onChange={(e) => setPdb(e.target.value)}
+                  placeholder="e.g. 1ABC or https://www.ebi.ac.uk/pdbe/entry-files/download/pdb3vte.ent"
                   className={typeAuxError ? "border-destructive" : ""}
                 />
+                <p className="text-muted-foreground text-xs">
+                  Enter an RCSB PDB ID (e.g. 1ABC) or a direct URL to a PDB file
+                </p>
               </div>
             )}
             {type === "repo" && (

--- a/dashboard/ui/src/pages/New.tsx
+++ b/dashboard/ui/src/pages/New.tsx
@@ -169,7 +169,7 @@ const New = () => {
                   id="pdb"
                   value={pdb}
                   onChange={(e) => setPdb(e.target.value)}
-                  placeholder="e.g. 1ABC or https://www.ebi.ac.uk/pdbe/entry-files/download/pdb3vte.ent"
+                  placeholder="e.g. 1ABC or https://files.rcsb.org/download/1AKI.pdb"
                   className={typeAuxError ? "border-destructive" : ""}
                 />
                 <p className="text-muted-foreground text-xs">

--- a/scripts/jwt_create_experiment.py
+++ b/scripts/jwt_create_experiment.py
@@ -161,7 +161,7 @@ def create_experiment():
     experiment_data = {
         "experiment-name": EXPERIMENT_NAME,
         "type": "pdb",
-        "pdb-id": PDB_ID,
+        "pdb": PDB_ID,
         "notebooks-repo": NOTEBOOKS_REPO,
     }
 


### PR DESCRIPTION
## Summary

Resolves #109.

Adds support for initializing an experiment from a direct URL to a PDB file (e.g. `https://www.ebi.ac.uk/pdbe/entry-files/download/pdb3vte.ent`), merged into the existing PDB option rather than adding a 4th tab. `Experiment.from_pdb` now accepts either an RCSB PDB ID or a direct `http(s)` URL; the form field is renamed `pdb-id` → `pdb` and the UI tab "PDB ID" → "PDB".

## Changes

- **API** (`dashboard/api/models/experiment.py`): `from_pdb` detects a URL via `urlparse(...).scheme` and fetches it directly; a plain value is treated as an RCSB PDB ID as before. Downloaded content is validated as a PDB file (requires at least one `ATOM`/`HETATM` record) before being persisted, so HTML error/login pages are rejected.
- **SSRF guard** (`dashboard/api/validators.py`): new `validate_http_url` (scheme/credentials/host) and `validate_fetch_target` (rejects literal IPs and resolved hostnames in reserved ranges: loopback/private/link-local/metadata/cluster-internal). `_fetch_pdb` follows redirects manually with `allow_redirects=False` and re-validates each hop. Shared URL-safety checks deduplicated via `_assert_http_url_safe`.
- **Route** (`dashboard/api/routes/experiments.py`): reads form field `pdb`.
- **UI** (`dashboard/ui/src/pages/New.tsx`): tab label "PDB", input "PDB ID or URL" with placeholder + help text showing both forms.
- **Script** (`scripts/jwt_create_experiment.py`): form field renamed.

## Tests

- `TestValidateHttpUrl` (9 cases) and `TestValidateFetchTarget` (12 cases: literal-IP + DNS-mocked hostname resolution).
- Integration tests: URL success, 404, `file://` rejection, internal-IP/host block, redirect-to-internal block, and HTML-content rejection (URL + PDB ID paths).
- Existing `pdb-id` tests migrated to `pdb`.

## Verification

- `make fix` (ruff format + check) ✓
- `make type-check` (ty + tsgo) ✓
- `make test` ✓ (282 + 19 + 91 + 61 passed)

## Threat model note

The SSRF guard resolves hostnames and checks every resolved IP against IANA reserved ranges (no enumerated hostname list). DNS rebinding is not defended; this is proportionate given the Dashboard API runs as a sidecar in the user's own namespace where the user already has equivalent network access from their notebook.

Co-Authored-By: glm-5.2 <no-reply@einfra.ai>