### PR TITLE
feat(notebooks): curated module selection with selective checkout

### DIFF
--- a/dashboard/api/app.py
+++ b/dashboard/api/app.py
@@ -120,10 +120,7 @@ def create_app() -> Flask:
     _register_blueprints(app)
     _log_duration("route-registration", reg_start)
 
-    # Validate the bundled notebook modules catalog at startup. Invalid product
-    # configuration is a startup error, not a recoverable user error. Runs before
-    # DB migrations so a bad catalog fails fast without leaving the database at a
-    # newer head than the (crashed) app.
+    # Validate bundled catalog before migrations so a bad catalog fails fast.
     catalog_start = time.perf_counter()
     load_catalog_or_exit()
     _log_duration("notebook-catalog", catalog_start)

--- a/dashboard/api/app.py
+++ b/dashboard/api/app.py
@@ -12,6 +12,7 @@ from extensions import db, ma, migrate
 from flask import Flask
 from flask_migrate import stamp, upgrade
 from logging_utils import configure_logging, enable_loggers
+from notebook_modules import load_catalog_or_exit
 from routes import (
     amber_bp,
     analysis_bp,
@@ -118,6 +119,14 @@ def create_app() -> Flask:
     reg_start = time.perf_counter()
     _register_blueprints(app)
     _log_duration("route-registration", reg_start)
+
+    # Validate the bundled notebook modules catalog at startup. Invalid product
+    # configuration is a startup error, not a recoverable user error. Runs before
+    # DB migrations so a bad catalog fails fast without leaving the database at a
+    # newer head than the (crashed) app.
+    catalog_start = time.perf_counter()
+    load_catalog_or_exit()
+    _log_duration("notebook-catalog", catalog_start)
 
     with app.app_context():
         _run_migrations()

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -286,19 +286,12 @@ class Experiment(db.Model):  # type: ignore
         notebook_module_id: str | None = None,
     ) -> str:
         """
-        Prepare environment directory for new experiment.
+        Create a unique experiment directory and populate it with notebooks.
 
-        When ``notebook_module_id`` is provided (curated mode), the module is
-        resolved from the bundled catalog, its engine is verified against
-        ``engine``, and only that module's directory is selectively checked out
-        from ``notebooks_repo`` (the configured default repository). Otherwise
-        (custom mode), the complete repository is cloned as before.
-
-        Args:
-            notebooks_repo: Git repository URL containing setup notebooks.
-            access_token: Optional access token for private repositories.
-            engine: Experiment engine; required when ``notebook_module_id`` is set.
-            notebook_module_id: Optional curated module ID for selective checkout.
+        Curated mode (``notebook_module_id`` set): resolve the module from the
+        catalog, verify engine match, and sparse-checkout its directory.
+        Root-path modules (``"."``) use full clone. Otherwise (custom mode),
+        clone the complete repository as before.
 
         Returns:
             The unique experiment ID.
@@ -372,7 +365,7 @@ class Experiment(db.Model):  # type: ignore
             name: Name of the experiment.
             pdb_source: PDB ID (e.g., 1A2B) or a direct URL to a PDB file.
             notebooks_repo: Git repository URL containing setup notebooks.
-            access_token: Optional GitHub access token for private repositories.
+            access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
             notebook_module_id: Optional curated module ID for selective checkout.
 
@@ -438,7 +431,7 @@ class Experiment(db.Model):  # type: ignore
             name: Name of the experiment.
             repo_link: Repository record URL.
             notebooks_repo: Git repository URL containing setup notebooks.
-            access_token: Optional GitHub access token for private repositories.
+            access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
             notebook_module_id: Optional curated module ID for selective checkout.
 
@@ -484,7 +477,7 @@ class Experiment(db.Model):  # type: ignore
             name: Name of the experiment.
             files: List of uploaded files.
             notebooks_repo: Git repository URL containing setup notebooks.
-            access_token: Optional GitHub access token for private repositories.
+            access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
             notebook_module_id: Optional curated module ID for selective checkout.
 

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -14,13 +14,21 @@ import yaml
 from cache import mdrepo_status_cache, step_status_cache
 from cachetools import cached
 from clients import mdposit, mdrepo, metadump
-from config import API_PREFIX, DATA_DIR, MDPOSIT_URL, MDPOSIT_VRE_LITE_URL, MDREPO_RECORD_NAME, MDREPO_URL
+from config import (
+    API_PREFIX,
+    DATA_DIR,
+    MDPOSIT_URL,
+    MDPOSIT_VRE_LITE_URL,
+    MDREPO_RECORD_NAME,
+    MDREPO_URL,
+)
 from enums import Engine, JobStatus, PodStatus
 from extensions import db
 from flask import session
+from notebook_modules import load_catalog
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from token_manager import MDRepoTokenManager
-from utils import download_git_repo, get_unique_id
+from utils import download_git_repo, download_git_repo_module, get_unique_id
 from validators import validate_fetch_target, validate_http_url
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
@@ -270,24 +278,50 @@ class Experiment(db.Model):  # type: ignore
         return None
 
     @classmethod
-    def prepare_env(cls, notebooks_repo: str, access_token: str | None = None) -> str:
+    def prepare_env(
+        cls,
+        notebooks_repo: str,
+        access_token: str | None = None,
+        engine: Engine | None = None,
+        notebook_module_id: str | None = None,
+    ) -> str:
         """
         Prepare environment directory for new experiment.
 
-        Creates a unique experiment directory and clones the notebooks repository into it.
+        When ``notebook_module_id`` is provided (curated mode), the module is
+        resolved from the bundled catalog, its engine is verified against
+        ``engine``, and only that module's directory is selectively checked out
+        from ``notebooks_repo`` (the configured default repository). Otherwise
+        (custom mode), the complete repository is cloned as before.
 
         Args:
             notebooks_repo: Git repository URL containing setup notebooks.
-            access_token: Optional GitHub access token for private repositories.
+            access_token: Optional access token for private repositories.
+            engine: Experiment engine; required when ``notebook_module_id`` is set.
+            notebook_module_id: Optional curated module ID for selective checkout.
 
         Returns:
             The unique experiment ID.
+
+        Raises:
+            BadRequest: If the module ID is unknown or engine-incompatible.
         """
         experiment_id: str = get_unique_id(DATA_DIR)
         experiment_dir = DATA_DIR / experiment_id
         experiment_dir.mkdir(parents=True, exist_ok=True)
         try:
-            download_git_repo(notebooks_repo, experiment_dir, access_token)
+            if notebook_module_id is not None:
+                if engine is None:
+                    raise BadRequest(description="Engine is required when a notebook module is selected.")
+                module = load_catalog().get_module_for_engine(notebook_module_id, engine.value)
+                if module is None:
+                    raise BadRequest(description=f"Unknown or incompatible notebook module: {notebook_module_id}")
+                if module.is_root:
+                    download_git_repo(notebooks_repo, experiment_dir, access_token)
+                else:
+                    download_git_repo_module(notebooks_repo, module.path, experiment_dir, access_token)
+            else:
+                download_git_repo(notebooks_repo, experiment_dir, access_token)
         except Exception:
             rmtree(experiment_dir, ignore_errors=True)
             raise
@@ -324,6 +358,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
+        notebook_module_id: str | None = None,
     ) -> "Experiment":
         """
         Create experiment from a PDB ID or a direct URL to a PDB file.
@@ -339,6 +374,7 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional GitHub access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
+            notebook_module_id: Optional curated module ID for selective checkout.
 
         Returns:
             The created Experiment instance.
@@ -347,7 +383,7 @@ class Experiment(db.Model):  # type: ignore
             NotFound: If the PDB ID or URL is not found.
             InternalServerError: If the PDB file download fails.
         """
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
         source = pdb_source.strip()
         is_url = bool(urlparse(source).scheme)
 
@@ -393,6 +429,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
+        notebook_module_id: str | None = None,
     ) -> "Experiment":
         """
         Create experiment from a supported repository URL.
@@ -403,11 +440,12 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional GitHub access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
+            notebook_module_id: Optional curated module ID for selective checkout.
 
         Returns:
             The created Experiment instance.
         """
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
 
         try:
             resolved_repo_link = _resolve_repo_link(repo_link)
@@ -437,6 +475,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
+        notebook_module_id: str | None = None,
     ) -> "Experiment":
         """
         Create experiment from file uploads with database persistence.
@@ -447,6 +486,7 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional GitHub access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
+            notebook_module_id: Optional curated module ID for selective checkout.
 
         Returns:
             The created Experiment instance.
@@ -457,7 +497,7 @@ class Experiment(db.Model):  # type: ignore
         if not files:
             raise BadRequest(description="No files provided")
 
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
 
         try:
             filenames = []

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -25,7 +25,7 @@ from config import (
 from enums import Engine, JobStatus, PodStatus
 from extensions import db
 from flask import session
-from notebook_modules import load_catalog
+from notebook_modules import NotebookModule
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from token_manager import MDRepoTokenManager
 from utils import download_git_repo, download_git_repo_module, get_unique_id
@@ -282,37 +282,26 @@ class Experiment(db.Model):  # type: ignore
         cls,
         notebooks_repo: str,
         access_token: str | None = None,
-        engine: Engine | None = None,
-        notebook_module_id: str | None = None,
+        notebook_module: NotebookModule | None = None,
     ) -> str:
         """
         Create a unique experiment directory and populate it with notebooks.
 
-        Curated mode (``notebook_module_id`` set): resolve the module from the
-        catalog, verify engine match, and sparse-checkout its directory.
-        Root-path modules (``"."``) use full clone. Otherwise (custom mode),
-        clone the complete repository as before.
+        Curated mode (``notebook_module`` set) sparse-checks out the module (root-path
+        ``"."`` uses full clone); custom mode clones the whole repository.
 
         Returns:
             The unique experiment ID.
-
-        Raises:
-            BadRequest: If the module ID is unknown or engine-incompatible.
         """
         experiment_id: str = get_unique_id(DATA_DIR)
         experiment_dir = DATA_DIR / experiment_id
         experiment_dir.mkdir(parents=True, exist_ok=True)
         try:
-            if notebook_module_id is not None:
-                if engine is None:
-                    raise BadRequest(description="Engine is required when a notebook module is selected.")
-                module = load_catalog().get_module_for_engine(notebook_module_id, engine.value)
-                if module is None:
-                    raise BadRequest(description=f"Unknown or incompatible notebook module: {notebook_module_id}")
-                if module.is_root:
+            if notebook_module is not None:
+                if notebook_module.is_root:
                     download_git_repo(notebooks_repo, experiment_dir, access_token)
                 else:
-                    download_git_repo_module(notebooks_repo, module.path, experiment_dir, access_token)
+                    download_git_repo_module(notebooks_repo, notebook_module.path, experiment_dir, access_token)
             else:
                 download_git_repo(notebooks_repo, experiment_dir, access_token)
         except Exception:
@@ -351,7 +340,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
-        notebook_module_id: str | None = None,
+        notebook_module: NotebookModule | None = None,
     ) -> "Experiment":
         """
         Create experiment from a PDB ID or a direct URL to a PDB file.
@@ -367,7 +356,7 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
-            notebook_module_id: Optional curated module ID for selective checkout.
+            notebook_module: Optional curated module for selective checkout.
 
         Returns:
             The created Experiment instance.
@@ -376,7 +365,7 @@ class Experiment(db.Model):  # type: ignore
             NotFound: If the PDB ID or URL is not found.
             InternalServerError: If the PDB file download fails.
         """
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, notebook_module)
         source = pdb_source.strip()
         is_url = bool(urlparse(source).scheme)
 
@@ -422,7 +411,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
-        notebook_module_id: str | None = None,
+        notebook_module: NotebookModule | None = None,
     ) -> "Experiment":
         """
         Create experiment from a supported repository URL.
@@ -433,12 +422,12 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
-            notebook_module_id: Optional curated module ID for selective checkout.
+            notebook_module: Optional curated module for selective checkout.
 
         Returns:
             The created Experiment instance.
         """
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, notebook_module)
 
         try:
             resolved_repo_link = _resolve_repo_link(repo_link)
@@ -468,7 +457,7 @@ class Experiment(db.Model):  # type: ignore
         notebooks_repo: str,
         access_token: str | None = None,
         engine: Engine = Engine.GMX,
-        notebook_module_id: str | None = None,
+        notebook_module: NotebookModule | None = None,
     ) -> "Experiment":
         """
         Create experiment from file uploads with database persistence.
@@ -479,7 +468,7 @@ class Experiment(db.Model):  # type: ignore
             notebooks_repo: Git repository URL containing setup notebooks.
             access_token: Optional access token for private repositories.
             engine: Molecular dynamics engine (default: GMX).
-            notebook_module_id: Optional curated module ID for selective checkout.
+            notebook_module: Optional curated module for selective checkout.
 
         Returns:
             The created Experiment instance.
@@ -490,7 +479,7 @@ class Experiment(db.Model):  # type: ignore
         if not files:
             raise BadRequest(description="No files provided")
 
-        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, engine, notebook_module_id)
+        experiment_id: str = cls.prepare_env(notebooks_repo, access_token, notebook_module)
 
         try:
             filenames = []

--- a/dashboard/api/notebook-modules.json
+++ b/dashboard/api/notebook-modules.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "./notebook-modules.schema.json",
+  "modules": [
+    {
+      "id": "gromacs-protein",
+      "name": "Protein",
+      "description": "Prepare and analyze a solvated protein with GROMACS.",
+      "engine": "GMX",
+      "path": "gromacs/protein"
+    },
+    {
+      "id": "amber-protein",
+      "name": "Protein",
+      "description": "Prepare a solvated protein with AMBER.",
+      "engine": "AMBER",
+      "path": "amber/protein"
+    },
+    {
+      "id": "biobb-membrane-gmx",
+      "name": "Membrane protein (BioBB)",
+      "description": "Set up a membrane protein system using BioExcel Building Blocks and GROMACS.",
+      "engine": "GMX",
+      "path": ".",
+      "repository": "https://github.com/bioexcel/biobb_wf_md_setup_membrane.git"
+    }
+  ]
+}

--- a/dashboard/api/notebook-modules.json
+++ b/dashboard/api/notebook-modules.json
@@ -16,6 +16,22 @@
       "path": "amber/protein"
     },
     {
+      "id": "biobb-protein-gmx",
+      "name": "Protein (BioBB)",
+      "description": "Set up a solvated protein system using BioExcel Building Blocks and GROMACS.",
+      "engine": "GMX",
+      "path": ".",
+      "repository": "https://github.com/bioexcel/biobb_wf_md_setup.git"
+    },
+    {
+      "id": "biobb-protein-amber",
+      "name": "Protein (BioBB)",
+      "description": "Set up a solvated protein system using BioExcel Building Blocks and AmberTools.",
+      "engine": "AMBER",
+      "path": ".",
+      "repository": "https://github.com/bioexcel/biobb_wf_amber.git"
+    },
+    {
       "id": "biobb-membrane-gmx",
       "name": "Membrane protein (BioBB)",
       "description": "Set up a membrane protein system using BioExcel Building Blocks and GROMACS.",

--- a/dashboard/api/notebook-modules.schema.json
+++ b/dashboard/api/notebook-modules.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mddash/schemas/notebook-modules.schema.json",
+  "title": "Notebook modules catalog",
+  "description": "Curated notebook modules shipped with the default notebooks repository.",
+  "type": "object",
+  "required": ["modules"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "$comment": "Optional reference to this schema, for editor/tooling validation of the catalog document."
+    },
+    "modules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "engine", "path"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "engine": {
+            "enum": ["GMX", "AMBER"]
+          },
+          "repository": {
+            "type": "string",
+            "$comment": "Optional Git repository URL. Defaults to the configured default notebooks repository when absent.",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "$comment": "Repository-relative directory path. Use '.' for the repository root (full clone, preserves Binder setup files at root).",
+            "minLength": 1,
+            "pattern": "^(?:\\.|[a-zA-Z0-9][a-zA-Z0-9 _./-]*)$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dashboard/api/notebook_modules.py
+++ b/dashboard/api/notebook_modules.py
@@ -84,15 +84,6 @@ class NotebookModulesCatalog:
         """
         return self.get(module_id, engine)
 
-    def for_engine(self, engine: str) -> list[NotebookModule]:
-        """
-        Return all modules compatible with the given engine.
-
-        Returns:
-            A list of modules whose engine matches.
-        """
-        return [m for m in self.modules if m.engine == engine]
-
     def to_public(self) -> list[dict]:
         """
         Return display metadata for all modules, excluding internal Git paths.

--- a/dashboard/api/notebook_modules.py
+++ b/dashboard/api/notebook_modules.py
@@ -33,35 +33,12 @@ class NotebookModule:
 
     @property
     def is_root(self) -> bool:
-        """Whether this module uses the repository root (full clone, no sparse checkout)."""
+        """True when path is '.', meaning full clone (preserves root Binder config)."""
         return self.path == ROOT_PATH
-
-    def resolve_path(self, base_dir: Path) -> Path:
-        """
-        Resolve this module's relative path against a base directory.
-
-        Returns:
-            The absolute path of the module directory inside ``base_dir``.
-        """
-        return base_dir / self.path
-
-    def to_dict(self) -> dict:
-        """
-        Return the internal representation including the server-side path.
-
-        Returns:
-            A dictionary with id, name, engine, path, and optional description/repository.
-        """
-        data: dict = {"id": self.id, "name": self.name, "engine": self.engine, "path": self.path}
-        if self.description is not None:
-            data["description"] = self.description
-        if self.repository is not None:
-            data["repository"] = self.repository
-        return data
 
     def to_public(self) -> dict:
         """
-        Return display metadata for the UI, excluding internal Git paths.
+        Display metadata for the UI, excluding internal Git paths.
 
         Returns:
             A dictionary with id, name, engine, and optional description.
@@ -89,7 +66,7 @@ class NotebookModulesCatalog:
         Return the module with the given ID, optionally requiring a matching engine.
 
         Returns:
-            The matching module, or None if no module matches.
+            The matching module, or None.
         """
         for module in self.modules:
             if module.id == module_id:
@@ -100,12 +77,21 @@ class NotebookModulesCatalog:
 
     def get_module_for_engine(self, module_id: str, engine: str) -> NotebookModule | None:
         """
-        Return the module matching both ID and engine, or None.
+        Return the module matching both ID and engine.
 
         Returns:
-            The matching module, or None if the ID is unknown or the engine differs.
+            The matching module, or None.
         """
         return self.get(module_id, engine)
+
+    def for_engine(self, engine: str) -> list[NotebookModule]:
+        """
+        Return all modules compatible with the given engine.
+
+        Returns:
+            A list of modules whose engine matches.
+        """
+        return [m for m in self.modules if m.engine == engine]
 
     def to_public(self) -> list[dict]:
         """
@@ -121,21 +107,12 @@ class NotebookModulesCatalog:
 
 
 def _load_schema() -> dict:
-    """
-    Load the bundled JSON Schema document.
-
-    Returns:
-        The parsed JSON Schema dictionary.
-    """
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
 def _build_catalog(data: dict) -> NotebookModulesCatalog:
     """
     Construct a NotebookModulesCatalog from validated raw data, enforcing unique IDs.
-
-    Args:
-        data: The raw parsed catalog dictionary.
 
     Returns:
         The validated NotebookModulesCatalog.
@@ -166,14 +143,7 @@ def _build_catalog(data: dict) -> NotebookModulesCatalog:
 @lru_cache(maxsize=1)
 def load_catalog(path: Path | None = None) -> NotebookModulesCatalog:
     """
-    Load and validate the curated notebook modules catalog.
-
-    The bundled catalog is immutable and already validated once at startup, so
-    results are memoized (keyed on ``path``). Test-only loads via an explicit
-    ``path`` use distinct keys and are not shared with the default entry.
-
-    Args:
-        path: Optional path to a catalog file. Defaults to the bundled catalog.
+    Load and validate the curated notebook modules catalog from the bundled JSON file.
 
     Returns:
         The validated NotebookModulesCatalog.
@@ -187,10 +157,7 @@ def load_catalog(path: Path | None = None) -> NotebookModulesCatalog:
 
 def load_catalog_or_exit(path: Path | None = None) -> NotebookModulesCatalog:
     """
-    Load the catalog, logging a fatal error and exiting on failure.
-
-    Used at application startup where invalid bundled product configuration
-    is a startup error, not a recoverable user error.
+    Load the catalog or exit with a fatal error. Used at startup.
 
     Returns:
         The validated NotebookModulesCatalog.

--- a/dashboard/api/notebook_modules.py
+++ b/dashboard/api/notebook_modules.py
@@ -1,0 +1,205 @@
+"""Curated notebook modules catalog bundled with the Dashboard API."""
+
+import json
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import overload
+
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema import ValidationError as JsonSchemaValidationError
+
+logger = logging.getLogger(__name__)
+
+_MODULE_DIR = Path(__file__).resolve().parent
+CATALOG_PATH = _MODULE_DIR / "notebook-modules.json"
+SCHEMA_PATH = _MODULE_DIR / "notebook-modules.schema.json"
+
+ROOT_PATH = "."
+
+
+@dataclass(frozen=True)
+class NotebookModule:
+    """A single curated notebook module entry."""
+
+    id: str
+    name: str
+    description: str | None
+    engine: str
+    path: str
+    repository: str | None = None
+
+    @property
+    def is_root(self) -> bool:
+        """Whether this module uses the repository root (full clone, no sparse checkout)."""
+        return self.path == ROOT_PATH
+
+    def resolve_path(self, base_dir: Path) -> Path:
+        """
+        Resolve this module's relative path against a base directory.
+
+        Returns:
+            The absolute path of the module directory inside ``base_dir``.
+        """
+        return base_dir / self.path
+
+    def to_dict(self) -> dict:
+        """
+        Return the internal representation including the server-side path.
+
+        Returns:
+            A dictionary with id, name, engine, path, and optional description/repository.
+        """
+        data: dict = {"id": self.id, "name": self.name, "engine": self.engine, "path": self.path}
+        if self.description is not None:
+            data["description"] = self.description
+        if self.repository is not None:
+            data["repository"] = self.repository
+        return data
+
+    def to_public(self) -> dict:
+        """
+        Return display metadata for the UI, excluding internal Git paths.
+
+        Returns:
+            A dictionary with id, name, engine, and optional description.
+        """
+        data: dict = {"id": self.id, "name": self.name, "engine": self.engine}
+        if self.description is not None:
+            data["description"] = self.description
+        return data
+
+
+@dataclass(frozen=True)
+class NotebookModulesCatalog:
+    """Validated collection of curated notebook modules."""
+
+    modules: tuple[NotebookModule, ...]
+
+    @overload
+    def get(self, module_id: str) -> NotebookModule | None: ...
+
+    @overload
+    def get(self, module_id: str, engine: str) -> NotebookModule | None: ...
+
+    def get(self, module_id: str, engine: str | None = None) -> NotebookModule | None:
+        """
+        Return the module with the given ID, optionally requiring a matching engine.
+
+        Returns:
+            The matching module, or None if no module matches.
+        """
+        for module in self.modules:
+            if module.id == module_id:
+                if engine is None or module.engine == engine:
+                    return module
+                return None
+        return None
+
+    def get_module_for_engine(self, module_id: str, engine: str) -> NotebookModule | None:
+        """
+        Return the module matching both ID and engine, or None.
+
+        Returns:
+            The matching module, or None if the ID is unknown or the engine differs.
+        """
+        return self.get(module_id, engine)
+
+    def to_public(self) -> list[dict]:
+        """
+        Return display metadata for all modules, excluding internal Git paths.
+
+        Returns:
+            A list of public module dictionaries.
+        """
+        return [m.to_public() for m in self.modules]
+
+    def __iter__(self) -> Iterator[NotebookModule]:
+        return iter(self.modules)
+
+
+def _load_schema() -> dict:
+    """
+    Load the bundled JSON Schema document.
+
+    Returns:
+        The parsed JSON Schema dictionary.
+    """
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _build_catalog(data: dict) -> NotebookModulesCatalog:
+    """
+    Construct a NotebookModulesCatalog from validated raw data, enforcing unique IDs.
+
+    Args:
+        data: The raw parsed catalog dictionary.
+
+    Returns:
+        The validated NotebookModulesCatalog.
+
+    Raises:
+        ValueError: If module IDs are not unique.
+    """
+    modules: list[NotebookModule] = []
+    seen_ids: set[str] = set()
+    for raw in data["modules"]:
+        module_id = raw["id"]
+        if module_id in seen_ids:
+            raise ValueError(f"Duplicate notebook module id: {module_id}")
+        seen_ids.add(module_id)
+        modules.append(
+            NotebookModule(
+                id=module_id,
+                name=raw["name"],
+                description=raw.get("description"),
+                engine=raw["engine"],
+                path=raw["path"],
+                repository=raw.get("repository"),
+            )
+        )
+    return NotebookModulesCatalog(modules=tuple(modules))
+
+
+@lru_cache(maxsize=1)
+def load_catalog(path: Path | None = None) -> NotebookModulesCatalog:
+    """
+    Load and validate the curated notebook modules catalog.
+
+    The bundled catalog is immutable and already validated once at startup, so
+    results are memoized (keyed on ``path``). Test-only loads via an explicit
+    ``path`` use distinct keys and are not shared with the default entry.
+
+    Args:
+        path: Optional path to a catalog file. Defaults to the bundled catalog.
+
+    Returns:
+        The validated NotebookModulesCatalog.
+    """
+    catalog_path = path or CATALOG_PATH
+    raw = json.loads(catalog_path.read_text(encoding="utf-8"))
+    schema = _load_schema()
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(raw)
+    return _build_catalog(raw)
+
+
+def load_catalog_or_exit(path: Path | None = None) -> NotebookModulesCatalog:
+    """
+    Load the catalog, logging a fatal error and exiting on failure.
+
+    Used at application startup where invalid bundled product configuration
+    is a startup error, not a recoverable user error.
+
+    Returns:
+        The validated NotebookModulesCatalog.
+
+    Raises:
+        SystemExit: If the catalog cannot be loaded or validated.
+    """
+    try:
+        return load_catalog(path)
+    except (FileNotFoundError, JsonSchemaValidationError, ValueError, json.JSONDecodeError) as exc:
+        logger.critical("Failed to load notebook modules catalog: %s", exc)
+        raise SystemExit(1) from exc

--- a/dashboard/api/routes/experiments.py
+++ b/dashboard/api/routes/experiments.py
@@ -7,6 +7,7 @@ from extensions import db
 from flask import Blueprint, Response, jsonify, request, session
 from flask.typing import ResponseReturnValue
 from models import Experiment
+from notebook_modules import load_catalog
 from schemas import ExperimentSchema
 from token_manager import MDRepoTokenManager
 from validators import validate_git_url
@@ -49,6 +50,7 @@ def create_experiment() -> ResponseReturnValue:
     repo_url = form.get("repo-url")
     notebooks_repo = form.get("notebooks-repo", DEFAULT_NOTEBOOKS_REPO)
     access_token = form.get("access-token")
+    notebook_module_id = form.get("notebook-module") or None
     simulation_files = request.files.getlist("simulation-files")
 
     # Get engine from form, default to GMX
@@ -58,15 +60,36 @@ def create_experiment() -> ResponseReturnValue:
     except ValueError:
         raise BadRequest(f"Invalid engine: {engine_str}")
 
-    validate_git_url(notebooks_repo)
+    if notebook_module_id is not None:
+        # Curated mode: resolve the module from the bundled catalog and use its
+        # configured repository (defaults to the platform default). No
+        # client-provided repository URL or path is trusted.
+        module = load_catalog().get_module_for_engine(notebook_module_id, engine.value)
+        if module is None:
+            raise BadRequest(f"Unknown or incompatible notebook module: {notebook_module_id}")
+        notebooks_repo = module.repository or DEFAULT_NOTEBOOKS_REPO
+    else:
+        # Custom mode: validate the client-provided repository URL.
+        validate_git_url(notebooks_repo)
 
     match form["type"]:
         case "pdb" if pdb_source:
-            experiment = Experiment.from_pdb(name, pdb_source, notebooks_repo, access_token, engine=engine)
+            experiment = Experiment.from_pdb(
+                name, pdb_source, notebooks_repo, access_token, engine=engine, notebook_module_id=notebook_module_id
+            )
         case "repo" if repo_url:
-            experiment = Experiment.from_repo(name, repo_url, notebooks_repo, access_token, engine=engine)
+            experiment = Experiment.from_repo(
+                name, repo_url, notebooks_repo, access_token, engine=engine, notebook_module_id=notebook_module_id
+            )
         case "file" if simulation_files:
-            experiment = Experiment.from_files(name, simulation_files, notebooks_repo, access_token, engine=engine)
+            experiment = Experiment.from_files(
+                name,
+                simulation_files,
+                notebooks_repo,
+                access_token,
+                engine=engine,
+                notebook_module_id=notebook_module_id,
+            )
         case _:
             raise BadRequest("Invalid experiment type or missing data.")
 

--- a/dashboard/api/routes/experiments.py
+++ b/dashboard/api/routes/experiments.py
@@ -60,23 +60,29 @@ def create_experiment() -> ResponseReturnValue:
     except ValueError:
         raise BadRequest(f"Invalid engine: {engine_str}")
 
+    module = None
     if notebook_module_id is not None:
         # Curated mode: server resolves module and repository; no client URL trusted.
         module = load_catalog().get_module_for_engine(notebook_module_id, engine.value)
         if module is None:
             raise BadRequest(f"Unknown or incompatible notebook module: {notebook_module_id}")
         notebooks_repo = module.repository or DEFAULT_NOTEBOOKS_REPO
+        if module.repository is not None:
+            # Guard against unsafe schemes even on trusted catalog URLs.
+            validate_git_url(module.repository)
+        # Never forward a client token to a curated (server-trusted) repository.
+        access_token = None
     else:
         validate_git_url(notebooks_repo)
 
     match form["type"]:
         case "pdb" if pdb_source:
             experiment = Experiment.from_pdb(
-                name, pdb_source, notebooks_repo, access_token, engine=engine, notebook_module_id=notebook_module_id
+                name, pdb_source, notebooks_repo, access_token, engine=engine, notebook_module=module
             )
         case "repo" if repo_url:
             experiment = Experiment.from_repo(
-                name, repo_url, notebooks_repo, access_token, engine=engine, notebook_module_id=notebook_module_id
+                name, repo_url, notebooks_repo, access_token, engine=engine, notebook_module=module
             )
         case "file" if simulation_files:
             experiment = Experiment.from_files(
@@ -85,7 +91,7 @@ def create_experiment() -> ResponseReturnValue:
                 notebooks_repo,
                 access_token,
                 engine=engine,
-                notebook_module_id=notebook_module_id,
+                notebook_module=module,
             )
         case _:
             raise BadRequest("Invalid experiment type or missing data.")

--- a/dashboard/api/routes/experiments.py
+++ b/dashboard/api/routes/experiments.py
@@ -61,15 +61,12 @@ def create_experiment() -> ResponseReturnValue:
         raise BadRequest(f"Invalid engine: {engine_str}")
 
     if notebook_module_id is not None:
-        # Curated mode: resolve the module from the bundled catalog and use its
-        # configured repository (defaults to the platform default). No
-        # client-provided repository URL or path is trusted.
+        # Curated mode: server resolves module and repository; no client URL trusted.
         module = load_catalog().get_module_for_engine(notebook_module_id, engine.value)
         if module is None:
             raise BadRequest(f"Unknown or incompatible notebook module: {notebook_module_id}")
         notebooks_repo = module.repository or DEFAULT_NOTEBOOKS_REPO
     else:
-        # Custom mode: validate the client-provided repository URL.
         validate_git_url(notebooks_repo)
 
     match form["type"]:

--- a/dashboard/api/routes/misc.py
+++ b/dashboard/api/routes/misc.py
@@ -25,13 +25,10 @@ def index() -> Response:
 @handle_exceptions()
 def get_notebook_modules() -> Response:
     """
-    Get the curated notebook modules catalog for display.
-
-    Returns display metadata (id, name, engine, description) only. Internal
-    Git paths and repository URLs are not exposed to the client.
+    Return curated notebook module display metadata (no internal paths or URLs).
 
     Returns:
-        Response: JSON response with the list of curated notebook modules.
+        JSON response with the list of curated notebook modules.
     """
     catalog = load_catalog()
     return jsonify(catalog.to_public())

--- a/dashboard/api/routes/misc.py
+++ b/dashboard/api/routes/misc.py
@@ -2,6 +2,7 @@ from cache import metrics_cache
 from config import API_PREFIX, CPU_REQUEST_QUOTA, DATA_DIR, MEMORY_REQUEST_QUOTA, PVC_SIZE
 from decorators import handle_exceptions
 from flask import Blueprint, Response, jsonify
+from notebook_modules import load_catalog
 from utils import get_du_size
 
 misc_bp = Blueprint("misc", __name__, url_prefix=API_PREFIX)
@@ -18,6 +19,22 @@ def index() -> Response:
         Response: JSON response confirming the API is running.
     """
     return jsonify("API is up!")
+
+
+@misc_bp.route("/notebook-modules", methods=["GET"])
+@handle_exceptions()
+def get_notebook_modules() -> Response:
+    """
+    Get the curated notebook modules catalog for display.
+
+    Returns display metadata (id, name, engine, description) only. Internal
+    Git paths and repository URLs are not exposed to the client.
+
+    Returns:
+        Response: JSON response with the list of curated notebook modules.
+    """
+    catalog = load_catalog()
+    return jsonify(catalog.to_public())
 
 
 @misc_bp.route("/metrics", methods=["GET"])

--- a/dashboard/api/tests/integration/test_experiments.py
+++ b/dashboard/api/tests/integration/test_experiments.py
@@ -533,8 +533,8 @@ class TestCreateExperimentCuratedModule:
             data = json.loads(response.data)
             assert data["notebooks_repo"] == "https://github.com/default/repo.git"
 
-    def test_curated_rejects_engine_mismatch(self, client: FlaskClient, tmp_path: Path) -> None:
-        """Curated creation should reject a module whose engine differs from the experiment."""
+    def test_curated_rejects_invalid_module(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Curated creation should reject an unknown or engine-incompatible module ID."""
         with (
             patch("models.experiment.DATA_DIR", tmp_path),
             patch("models.experiment.download_git_repo_module") as mock_module,
@@ -543,30 +543,9 @@ class TestCreateExperimentCuratedModule:
                 "/dash/api/experiments",
                 data={
                     "type": "file",
-                    "experiment-name": "Engine Mismatch",
+                    "experiment-name": "Invalid Module",
                     "engine": "AMBER",
                     "notebook-module": "gromacs-protein",
-                    "simulation-files": [(io.BytesIO(b"content"), "test.gro")],
-                },
-                content_type="multipart/form-data",
-            )
-
-            assert response.status_code == HTTPStatus.BAD_REQUEST
-            mock_module.assert_not_called()
-
-    def test_curated_rejects_unknown_module(self, client: FlaskClient, tmp_path: Path) -> None:
-        """Curated creation should reject an unknown module ID."""
-        with (
-            patch("models.experiment.DATA_DIR", tmp_path),
-            patch("models.experiment.download_git_repo_module") as mock_module,
-        ):
-            response = client.post(
-                "/dash/api/experiments",
-                data={
-                    "type": "file",
-                    "experiment-name": "Unknown Module",
-                    "engine": "GMX",
-                    "notebook-module": "no-such-module",
                     "simulation-files": [(io.BytesIO(b"content"), "test.gro")],
                 },
                 content_type="multipart/form-data",

--- a/dashboard/api/tests/integration/test_experiments.py
+++ b/dashboard/api/tests/integration/test_experiments.py
@@ -605,7 +605,6 @@ class TestCreateExperimentCuratedModule:
             patch("models.experiment.download_git_repo") as mock_full,
             patch("models.experiment.download_git_repo_module") as mock_module,
             patch("routes.experiments.load_catalog", return_value=catalog),
-            patch("models.experiment.load_catalog", return_value=catalog),
         ):
             mock_response = MagicMock()
             mock_response.status_code = 200

--- a/dashboard/api/tests/integration/test_experiments.py
+++ b/dashboard/api/tests/integration/test_experiments.py
@@ -497,6 +497,161 @@ class TestCreateExperiment:
             assert (exp_dir / expected_name_2).exists()
 
 
+class TestCreateExperimentCuratedModule:
+    """Tests for POST /api/experiments with curated notebook module selection."""
+
+    def test_curated_uses_selective_checkout(
+        self, client: FlaskClient, sample_pdb_content: bytes, tmp_path: Path
+    ) -> None:
+        """Curated creation should use the selective module checkout, not the full clone."""
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("routes.experiments.DEFAULT_NOTEBOOKS_REPO", "https://github.com/default/repo.git"),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = sample_pdb_content
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Curated Experiment",
+                    "pdb": "1ABC",
+                    "engine": "GMX",
+                    "notebook-module": "gromacs-protein",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.CREATED
+            mock_full.assert_not_called()
+            mock_module.assert_called_once()
+            data = json.loads(response.data)
+            assert data["notebooks_repo"] == "https://github.com/default/repo.git"
+
+    def test_curated_rejects_engine_mismatch(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Curated creation should reject a module whose engine differs from the experiment."""
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module") as mock_module,
+        ):
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "file",
+                    "experiment-name": "Engine Mismatch",
+                    "engine": "AMBER",
+                    "notebook-module": "gromacs-protein",
+                    "simulation-files": [(io.BytesIO(b"content"), "test.gro")],
+                },
+                content_type="multipart/form-data",
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            mock_module.assert_not_called()
+
+    def test_curated_rejects_unknown_module(self, client: FlaskClient, tmp_path: Path) -> None:
+        """Curated creation should reject an unknown module ID."""
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module") as mock_module,
+        ):
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "file",
+                    "experiment-name": "Unknown Module",
+                    "engine": "GMX",
+                    "notebook-module": "no-such-module",
+                    "simulation-files": [(io.BytesIO(b"content"), "test.gro")],
+                },
+                content_type="multipart/form-data",
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            mock_module.assert_not_called()
+
+    def test_custom_mode_without_module_uses_full_clone(
+        self, client: FlaskClient, sample_pdb_content: bytes, tmp_path: Path
+    ) -> None:
+        """Without a module ID, custom mode should use the full clone path."""
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = sample_pdb_content
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Custom Experiment",
+                    "pdb": "1ABC",
+                    "notebooks-repo": "https://github.com/custom/repo.git",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.CREATED
+            mock_full.assert_called_once()
+            mock_module.assert_not_called()
+
+    def test_curated_module_with_repository_stores_module_url(
+        self, client: FlaskClient, sample_pdb_content: bytes, tmp_path: Path
+    ) -> None:
+        """A curated module with a repository field should store that URL in the experiment."""
+        import notebook_modules  # ruff:ignore[import-outside-top-level]
+
+        binder_module = notebook_modules.NotebookModule(
+            id="binder-gmx",
+            name="Binder",
+            description="d",
+            engine="GMX",
+            path=".",
+            repository="https://github.com/bioexcel/biobb_wf_md_setup_membrane.git",
+        )
+        catalog = notebook_modules.NotebookModulesCatalog(modules=(binder_module,))
+
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("routes.experiments.load_catalog", return_value=catalog),
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = sample_pdb_content
+            mock_get.return_value = mock_response
+
+            response = client.post(
+                "/dash/api/experiments",
+                data={
+                    "type": "pdb",
+                    "experiment-name": "Binder Experiment",
+                    "pdb": "1ABC",
+                    "engine": "GMX",
+                    "notebook-module": "binder-gmx",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.CREATED
+            data = json.loads(response.data)
+            assert data["notebooks_repo"] == "https://github.com/bioexcel/biobb_wf_md_setup_membrane.git"
+            # Root-path module uses full clone, not sparse checkout
+            mock_full.assert_called_once()
+            mock_module.assert_not_called()
+
+
 class TestEditExperiment:
     """Tests for PATCH /api/experiments/<id>."""
 

--- a/dashboard/api/tests/integration/test_notebook_modules_route.py
+++ b/dashboard/api/tests/integration/test_notebook_modules_route.py
@@ -11,8 +11,8 @@ MIN_MODULE_COUNT = 2
 class TestNotebookModulesEndpoint:
     """Tests for GET /api/notebook-modules."""
 
-    def test_returns_catalog_display_metadata(self, client: FlaskClient) -> None:
-        """Should return modules with display fields and no internal paths."""
+    def test_returns_display_metadata_without_internal_paths(self, client: FlaskClient) -> None:
+        """Should return modules with display fields, no internal paths/URLs, JSON-serializable."""
         response = client.get("/dash/api/notebook-modules")
 
         assert response.status_code == HTTPStatus.OK
@@ -22,32 +22,14 @@ class TestNotebookModulesEndpoint:
 
         ids = {m["id"] for m in data}
         assert "gromacs-protein" in ids
-        assert "amber-protein" in ids
 
-    def test_response_excludes_internal_paths(self, client: FlaskClient) -> None:
-        """The catalog response must not expose internal Git paths or repository URLs."""
-        response = client.get("/dash/api/notebook-modules")
-
-        data = json.loads(response.data)
-        for module in data:
-            assert "path" not in module
-            assert "repository" not in module
-            assert "url" not in module
-
-    def test_response_includes_required_display_fields(self, client: FlaskClient) -> None:
-        """Each module entry should include id, name, engine, and description."""
-        response = client.get("/dash/api/notebook-modules")
-
-        data = json.loads(response.data)
         for module in data:
             assert "id" in module
             assert "name" in module
             assert "engine" in module
             assert module["engine"] in {"GMX", "AMBER"}
+            assert "path" not in module
+            assert "repository" not in module
+            assert "url" not in module
 
-    def test_response_is_json_serializable(self, client: FlaskClient) -> None:
-        """The catalog response should be JSON-serializable as-is."""
-        response = client.get("/dash/api/notebook-modules")
-
-        data = json.loads(response.data)
         json.dumps(data)

--- a/dashboard/api/tests/integration/test_notebook_modules_route.py
+++ b/dashboard/api/tests/integration/test_notebook_modules_route.py
@@ -1,0 +1,53 @@
+"""Integration tests for the notebook modules catalog endpoint."""
+
+import json
+from http import HTTPStatus
+
+from flask.testing import FlaskClient
+
+MIN_MODULE_COUNT = 2
+
+
+class TestNotebookModulesEndpoint:
+    """Tests for GET /api/notebook-modules."""
+
+    def test_returns_catalog_display_metadata(self, client: FlaskClient) -> None:
+        """Should return modules with display fields and no internal paths."""
+        response = client.get("/dash/api/notebook-modules")
+
+        assert response.status_code == HTTPStatus.OK
+        data = json.loads(response.data)
+        assert isinstance(data, list)
+        assert len(data) >= MIN_MODULE_COUNT
+
+        ids = {m["id"] for m in data}
+        assert "gromacs-protein" in ids
+        assert "amber-protein" in ids
+
+    def test_response_excludes_internal_paths(self, client: FlaskClient) -> None:
+        """The catalog response must not expose internal Git paths or repository URLs."""
+        response = client.get("/dash/api/notebook-modules")
+
+        data = json.loads(response.data)
+        for module in data:
+            assert "path" not in module
+            assert "repository" not in module
+            assert "url" not in module
+
+    def test_response_includes_required_display_fields(self, client: FlaskClient) -> None:
+        """Each module entry should include id, name, engine, and description."""
+        response = client.get("/dash/api/notebook-modules")
+
+        data = json.loads(response.data)
+        for module in data:
+            assert "id" in module
+            assert "name" in module
+            assert "engine" in module
+            assert module["engine"] in {"GMX", "AMBER"}
+
+    def test_response_is_json_serializable(self, client: FlaskClient) -> None:
+        """The catalog response should be JSON-serializable as-is."""
+        response = client.get("/dash/api/notebook-modules")
+
+        data = json.loads(response.data)
+        json.dumps(data)

--- a/dashboard/api/tests/unit/test_experiment_curated.py
+++ b/dashboard/api/tests/unit/test_experiment_curated.py
@@ -1,0 +1,180 @@
+"""Unit tests for experiment factory curated module support."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from enums import Engine
+from flask import Flask
+from models.experiment import Experiment
+from notebook_modules import NotebookModule, NotebookModulesCatalog
+from sqlalchemy.orm import Session
+from werkzeug.exceptions import BadRequest, InternalServerError
+
+
+def _gmx_module() -> NotebookModule:
+    return NotebookModule(id="gromacs-protein", name="Protein", description="d", engine="GMX", path="gromacs/protein")
+
+
+def _amber_module() -> NotebookModule:
+    return NotebookModule(id="amber-protein", name="Protein", description="d", engine="AMBER", path="amber/protein")
+
+
+def _binder_module() -> NotebookModule:
+    return NotebookModule(
+        id="binder-gmx",
+        name="Binder",
+        description="d",
+        engine="GMX",
+        path=".",
+        repository="https://github.com/bioexcel/biobb_wf_md_setup_membrane.git",
+    )
+
+
+def _catalog(modules: list[NotebookModule]) -> NotebookModulesCatalog:
+    return NotebookModulesCatalog(modules=tuple(modules))
+
+
+class TestPrepareEnvCurated:
+    """Tests for prepare_env with a curated notebook module ID."""
+
+    def test_curated_uses_selective_checkout_with_module_path(self, tmp_path: Path) -> None:
+        """prepare_env with a module ID should selectively check out the module path."""
+        catalog = _catalog([_gmx_module()])
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            exp_id = Experiment.prepare_env(
+                notebooks_repo="https://github.com/default/repo.git",
+                engine=Engine.GMX,
+                notebook_module_id="gromacs-protein",
+            )
+
+            mock_full.assert_not_called()
+            mock_module.assert_called_once()
+            call_args = mock_module.call_args
+            assert call_args.args[1] == "gromacs/protein"
+            assert call_args.args[0] == "https://github.com/default/repo.git"
+            assert (tmp_path / exp_id).exists()
+
+    def test_curated_rejects_engine_mismatch(self, tmp_path: Path) -> None:
+        """A module ID whose engine differs from the experiment engine should raise BadRequest."""
+        catalog = _catalog([_gmx_module()])
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            with pytest.raises(BadRequest):
+                Experiment.prepare_env(
+                    notebooks_repo="https://github.com/default/repo.git",
+                    engine=Engine.AMBER,
+                    notebook_module_id="gromacs-protein",
+                )
+
+            mock_module.assert_not_called()
+
+    def test_curated_rejects_unknown_module_id(self, tmp_path: Path) -> None:
+        """An unknown module ID should raise BadRequest."""
+        catalog = _catalog([_gmx_module()])
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            with pytest.raises(BadRequest):
+                Experiment.prepare_env(
+                    notebooks_repo="https://github.com/default/repo.git",
+                    engine=Engine.GMX,
+                    notebook_module_id="no-such-module",
+                )
+
+            mock_module.assert_not_called()
+
+    def test_curated_cleanup_on_checkout_failure(self, tmp_path: Path) -> None:
+        """A checkout failure should remove the partial experiment directory."""
+        catalog = _catalog([_gmx_module()])
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module", side_effect=InternalServerError("fail")),
+            patch("models.experiment.load_catalog", return_value=catalog),
+            pytest.raises(InternalServerError),
+        ):
+            Experiment.prepare_env(
+                notebooks_repo="https://github.com/default/repo.git",
+                engine=Engine.GMX,
+                notebook_module_id="gromacs-protein",
+            )
+
+    def test_custom_mode_without_module_uses_full_clone(self, tmp_path: Path) -> None:
+        """Without a module ID, the existing full-clone path is used."""
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("models.experiment.load_catalog", return_value=_catalog([_gmx_module()])),
+        ):
+            Experiment.prepare_env(
+                notebooks_repo="https://github.com/custom/repo.git",
+                access_token="tok",
+            )
+
+            mock_full.assert_called_once()
+            mock_module.assert_not_called()
+
+    def test_root_path_module_uses_full_clone(self, tmp_path: Path) -> None:
+        """A module with path '.' should use full clone, not sparse checkout."""
+        catalog = _catalog([_binder_module()])
+        with (
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo") as mock_full,
+            patch("models.experiment.download_git_repo_module") as mock_module,
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            Experiment.prepare_env(
+                notebooks_repo="https://github.com/bioexcel/biobb_wf_md_setup_membrane.git",
+                engine=Engine.GMX,
+                notebook_module_id="binder-gmx",
+            )
+
+            mock_full.assert_called_once()
+            mock_module.assert_not_called()
+
+
+class TestFromPdbCurated:
+    """Tests for Experiment.from_pdb with curated modules."""
+
+    def test_from_pdb_curated_stores_default_repo(
+        self,
+        app: Flask,  # ruff:ignore[unused-method-argument]
+        db_session: Session,  # ruff:ignore[unused-method-argument]
+        tmp_path: Path,
+    ) -> None:
+        """Curated from_pdb should store the configured default repository URL."""
+        catalog = _catalog([_gmx_module()])
+        with (
+            patch("models.experiment.requests.get") as mock_get,
+            patch("models.experiment.DATA_DIR", tmp_path),
+            patch("models.experiment.download_git_repo_module"),
+            patch("models.experiment.load_catalog", return_value=catalog),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = (
+                b"ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N\nEND\n"
+            )
+            mock_get.return_value = mock_response
+
+            exp = Experiment.from_pdb(
+                name="Curated PDB",
+                pdb_source="1ABC",
+                notebooks_repo="https://github.com/default/repo.git",
+                engine=Engine.GMX,
+                notebook_module_id="gromacs-protein",
+            )
+
+            assert exp.notebooks_repo == "https://github.com/default/repo.git"
+            assert (tmp_path / exp.id / "input.pdb").exists()

--- a/dashboard/api/tests/unit/test_experiment_curated.py
+++ b/dashboard/api/tests/unit/test_experiment_curated.py
@@ -1,23 +1,17 @@
 """Unit tests for experiment factory curated module support."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from enums import Engine
-from flask import Flask
 from models.experiment import Experiment
 from notebook_modules import NotebookModule, NotebookModulesCatalog
-from sqlalchemy.orm import Session
-from werkzeug.exceptions import BadRequest, InternalServerError
+from werkzeug.exceptions import InternalServerError
 
 
 def _gmx_module() -> NotebookModule:
     return NotebookModule(id="gromacs-protein", name="Protein", description="d", engine="GMX", path="gromacs/protein")
-
-
-def _amber_module() -> NotebookModule:
-    return NotebookModule(id="amber-protein", name="Protein", description="d", engine="AMBER", path="amber/protein")
 
 
 def _binder_module() -> NotebookModule:
@@ -55,44 +49,8 @@ class TestPrepareEnvCurated:
 
             mock_full.assert_not_called()
             mock_module.assert_called_once()
-            call_args = mock_module.call_args
-            assert call_args.args[1] == "gromacs/protein"
-            assert call_args.args[0] == "https://github.com/default/repo.git"
+            assert mock_module.call_args.args[1] == "gromacs/protein"
             assert (tmp_path / exp_id).exists()
-
-    def test_curated_rejects_engine_mismatch(self, tmp_path: Path) -> None:
-        """A module ID whose engine differs from the experiment engine should raise BadRequest."""
-        catalog = _catalog([_gmx_module()])
-        with (
-            patch("models.experiment.DATA_DIR", tmp_path),
-            patch("models.experiment.download_git_repo_module") as mock_module,
-            patch("models.experiment.load_catalog", return_value=catalog),
-        ):
-            with pytest.raises(BadRequest):
-                Experiment.prepare_env(
-                    notebooks_repo="https://github.com/default/repo.git",
-                    engine=Engine.AMBER,
-                    notebook_module_id="gromacs-protein",
-                )
-
-            mock_module.assert_not_called()
-
-    def test_curated_rejects_unknown_module_id(self, tmp_path: Path) -> None:
-        """An unknown module ID should raise BadRequest."""
-        catalog = _catalog([_gmx_module()])
-        with (
-            patch("models.experiment.DATA_DIR", tmp_path),
-            patch("models.experiment.download_git_repo_module") as mock_module,
-            patch("models.experiment.load_catalog", return_value=catalog),
-        ):
-            with pytest.raises(BadRequest):
-                Experiment.prepare_env(
-                    notebooks_repo="https://github.com/default/repo.git",
-                    engine=Engine.GMX,
-                    notebook_module_id="no-such-module",
-                )
-
-            mock_module.assert_not_called()
 
     def test_curated_cleanup_on_checkout_failure(self, tmp_path: Path) -> None:
         """A checkout failure should remove the partial experiment directory."""
@@ -108,22 +66,6 @@ class TestPrepareEnvCurated:
                 engine=Engine.GMX,
                 notebook_module_id="gromacs-protein",
             )
-
-    def test_custom_mode_without_module_uses_full_clone(self, tmp_path: Path) -> None:
-        """Without a module ID, the existing full-clone path is used."""
-        with (
-            patch("models.experiment.DATA_DIR", tmp_path),
-            patch("models.experiment.download_git_repo") as mock_full,
-            patch("models.experiment.download_git_repo_module") as mock_module,
-            patch("models.experiment.load_catalog", return_value=_catalog([_gmx_module()])),
-        ):
-            Experiment.prepare_env(
-                notebooks_repo="https://github.com/custom/repo.git",
-                access_token="tok",
-            )
-
-            mock_full.assert_called_once()
-            mock_module.assert_not_called()
 
     def test_root_path_module_uses_full_clone(self, tmp_path: Path) -> None:
         """A module with path '.' should use full clone, not sparse checkout."""
@@ -142,39 +84,3 @@ class TestPrepareEnvCurated:
 
             mock_full.assert_called_once()
             mock_module.assert_not_called()
-
-
-class TestFromPdbCurated:
-    """Tests for Experiment.from_pdb with curated modules."""
-
-    def test_from_pdb_curated_stores_default_repo(
-        self,
-        app: Flask,  # ruff:ignore[unused-method-argument]
-        db_session: Session,  # ruff:ignore[unused-method-argument]
-        tmp_path: Path,
-    ) -> None:
-        """Curated from_pdb should store the configured default repository URL."""
-        catalog = _catalog([_gmx_module()])
-        with (
-            patch("models.experiment.requests.get") as mock_get,
-            patch("models.experiment.DATA_DIR", tmp_path),
-            patch("models.experiment.download_git_repo_module"),
-            patch("models.experiment.load_catalog", return_value=catalog),
-        ):
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = (
-                b"ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N\nEND\n"
-            )
-            mock_get.return_value = mock_response
-
-            exp = Experiment.from_pdb(
-                name="Curated PDB",
-                pdb_source="1ABC",
-                notebooks_repo="https://github.com/default/repo.git",
-                engine=Engine.GMX,
-                notebook_module_id="gromacs-protein",
-            )
-
-            assert exp.notebooks_repo == "https://github.com/default/repo.git"
-            assert (tmp_path / exp.id / "input.pdb").exists()

--- a/dashboard/api/tests/unit/test_experiment_curated.py
+++ b/dashboard/api/tests/unit/test_experiment_curated.py
@@ -4,9 +4,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from enums import Engine
 from models.experiment import Experiment
-from notebook_modules import NotebookModule, NotebookModulesCatalog
+from notebook_modules import NotebookModule
 from werkzeug.exceptions import InternalServerError
 
 
@@ -25,26 +24,19 @@ def _binder_module() -> NotebookModule:
     )
 
 
-def _catalog(modules: list[NotebookModule]) -> NotebookModulesCatalog:
-    return NotebookModulesCatalog(modules=tuple(modules))
-
-
 class TestPrepareEnvCurated:
-    """Tests for prepare_env with a curated notebook module ID."""
+    """Tests for prepare_env with a curated notebook module."""
 
     def test_curated_uses_selective_checkout_with_module_path(self, tmp_path: Path) -> None:
-        """prepare_env with a module ID should selectively check out the module path."""
-        catalog = _catalog([_gmx_module()])
+        """prepare_env with a module should selectively check out the module path."""
         with (
             patch("models.experiment.DATA_DIR", tmp_path),
             patch("models.experiment.download_git_repo") as mock_full,
             patch("models.experiment.download_git_repo_module") as mock_module,
-            patch("models.experiment.load_catalog", return_value=catalog),
         ):
             exp_id = Experiment.prepare_env(
                 notebooks_repo="https://github.com/default/repo.git",
-                engine=Engine.GMX,
-                notebook_module_id="gromacs-protein",
+                notebook_module=_gmx_module(),
             )
 
             mock_full.assert_not_called()
@@ -54,32 +46,26 @@ class TestPrepareEnvCurated:
 
     def test_curated_cleanup_on_checkout_failure(self, tmp_path: Path) -> None:
         """A checkout failure should remove the partial experiment directory."""
-        catalog = _catalog([_gmx_module()])
         with (
             patch("models.experiment.DATA_DIR", tmp_path),
             patch("models.experiment.download_git_repo_module", side_effect=InternalServerError("fail")),
-            patch("models.experiment.load_catalog", return_value=catalog),
             pytest.raises(InternalServerError),
         ):
             Experiment.prepare_env(
                 notebooks_repo="https://github.com/default/repo.git",
-                engine=Engine.GMX,
-                notebook_module_id="gromacs-protein",
+                notebook_module=_gmx_module(),
             )
 
     def test_root_path_module_uses_full_clone(self, tmp_path: Path) -> None:
         """A module with path '.' should use full clone, not sparse checkout."""
-        catalog = _catalog([_binder_module()])
         with (
             patch("models.experiment.DATA_DIR", tmp_path),
             patch("models.experiment.download_git_repo") as mock_full,
             patch("models.experiment.download_git_repo_module") as mock_module,
-            patch("models.experiment.load_catalog", return_value=catalog),
         ):
             Experiment.prepare_env(
                 notebooks_repo="https://github.com/bioexcel/biobb_wf_md_setup_membrane.git",
-                engine=Engine.GMX,
-                notebook_module_id="binder-gmx",
+                notebook_module=_binder_module(),
             )
 
             mock_full.assert_called_once()

--- a/dashboard/api/tests/unit/test_git_module_checkout.py
+++ b/dashboard/api/tests/unit/test_git_module_checkout.py
@@ -1,0 +1,171 @@
+"""Unit tests for selective git checkout of curated notebook modules."""
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
+
+import pytest
+from utils import download_git_repo_module
+from werkzeug.exceptions import InternalServerError, NotFound
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+FIRST_CLONE_ATTEMPT = 1
+SECOND_CLONE_COUNT = 2
+
+
+def _make_real_repo(repo_dir: Path, module_path: str, other_path: str) -> None:
+    """Create a real local git repo with two module directories."""
+    repo_dir.mkdir(parents=True)
+    (repo_dir / module_path).mkdir(parents=True)
+    (repo_dir / module_path / "notebook.ipynb").write_text("nb")
+    (repo_dir / module_path / "gromacs.schema.json").write_text("{}")
+    (repo_dir / other_path).mkdir(parents=True)
+    (repo_dir / other_path / "other.ipynb").write_text("other")
+    (repo_dir / "README.md").write_text("root readme")
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.test"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo_dir, check=True)
+
+
+class TestDownloadGitRepoModule:
+    """Tests for download_git_repo_module (sparse checkout of a subdirectory)."""
+
+    def test_copies_only_selected_module_contents_into_target(self, tmp_path: Path) -> None:
+        """Only the selected module directory's contents should appear in target_dir."""
+        repo = tmp_path / "repo"
+        _make_real_repo(repo, "gromacs/protein", "amber/protein")
+
+        target = tmp_path / "target"
+
+        download_git_repo_module(str(repo), "gromacs/protein", target)
+
+        # Module contents are flattened into target (no module directory wrapper)
+        assert (target / "notebook.ipynb").read_text() == "nb"
+        assert (target / "gromacs.schema.json").read_text() == "{}"
+        # Other module and root files must NOT be present
+        assert not (target / "other.ipynb").exists()
+        assert not (target / "README.md").exists()
+        assert not (target / "amber").exists()
+        assert not (target / "gromacs").exists()
+        # No .git metadata
+        assert not (target / ".git").exists()
+
+    def test_missing_module_path_raises_not_found(self, tmp_path: Path) -> None:
+        """A module path absent from the repository should raise NotFound."""
+        repo = tmp_path / "repo"
+        _make_real_repo(repo, "gromacs/protein", "amber/protein")
+
+        target = tmp_path / "target"
+
+        with pytest.raises(NotFound):
+            download_git_repo_module(str(repo), "does/not/exist", target)
+
+    def test_clone_failure_raises_internal_server_error(self, tmp_path: Path) -> None:
+        """A git clone failure should raise InternalServerError without leaking credentials."""
+        target = tmp_path / "target"
+        error = subprocess.CalledProcessError(1, "git")
+        error.stderr = "fatal: repository not found"
+
+        with (
+            patch("utils.subprocess.run", side_effect=error),
+            pytest.raises(InternalServerError) as exc_info,
+        ):
+            download_git_repo_module(
+                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="secret-token"
+            )
+
+        assert "secret-token" not in str(exc_info.value)
+
+    def test_clone_timeout_raises_internal_server_error(self, tmp_path: Path) -> None:
+        """A clone timeout should raise InternalServerError."""
+        target = tmp_path / "target"
+
+        with (
+            patch("utils.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="git", timeout=1)),
+            pytest.raises(InternalServerError),
+        ):
+            download_git_repo_module("https://github.com/owner/repo.git", "gromacs/protein", target)
+
+    def test_uses_partial_clone_and_sparse_checkout(self, tmp_path: Path) -> None:
+        """The clone should use --no-checkout with blob filtering and sparse checkout."""
+        repo = tmp_path / "repo"
+        _make_real_repo(repo, "gromacs/protein", "amber/protein")
+        target = tmp_path / "target"
+
+        captured: list[list[str]] = []
+
+        real_run = cast("Callable[..., subprocess.CompletedProcess[str]]", subprocess.run)
+
+        def _capture(cmd: list[str] | str, *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if isinstance(cmd, list) and cmd[:1] == ["git"] and cmd[1:2] == ["clone"]:
+                captured.append(list(cmd))
+            return real_run(cmd, *args, **kwargs)
+
+        with patch("utils.subprocess.run", side_effect=_capture):
+            download_git_repo_module(str(repo), "gromacs/protein", target)
+
+        assert captured, "expected at least one git clone invocation"
+        clone_cmd = captured[0]
+        assert "--no-checkout" in clone_cmd
+        assert "--filter=blob:none" in clone_cmd
+        assert "--" in clone_cmd
+
+    def test_falls_back_to_shallow_clone_when_filter_unsupported(self, tmp_path: Path) -> None:
+        """When blob filtering fails, fall back to a normal shallow clone then sparse checkout."""
+        repo = tmp_path / "repo"
+        _make_real_repo(repo, "gromacs/protein", "amber/protein")
+        target = tmp_path / "target"
+
+        original_run = cast("Callable[..., subprocess.CompletedProcess[str]]", subprocess.run)
+        call_count = {"clone": 0}
+
+        def _flaky_clone(cmd: list[str] | str, *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if isinstance(cmd, list) and cmd[:1] == ["git"] and cmd[1:2] == ["clone"]:
+                call_count["clone"] += 1
+                if call_count["clone"] == FIRST_CLONE_ATTEMPT:
+                    raise subprocess.CalledProcessError(1, cmd, stderr="fatal: filter not supported")
+            return original_run(cmd, *args, **kwargs)
+
+        with patch("utils.subprocess.run", side_effect=_flaky_clone):
+            download_git_repo_module(str(repo), "gromacs/protein", target)
+
+        assert call_count["clone"] == SECOND_CLONE_COUNT
+        assert (target / "notebook.ipynb").exists()
+
+    def test_access_token_injected_for_https_url_not_in_error(self, tmp_path: Path) -> None:
+        """Tokens injected into HTTPS URLs must not appear in error messages."""
+        target = tmp_path / "target"
+        error = subprocess.CalledProcessError(1, "git")
+        error.stderr = "fatal: auth failure"
+
+        with (
+            patch("utils.subprocess.run", side_effect=error),
+            pytest.raises(InternalServerError) as exc_info,
+        ):
+            download_git_repo_module(
+                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
+            )
+
+        assert "ghp_secret" not in str(exc_info.value)
+
+    def test_access_token_not_logged_on_failure(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """The access token must never appear in log records when a clone fails."""
+        target = tmp_path / "target"
+        error = subprocess.CalledProcessError(1, "git")
+        error.stderr = "fatal: auth failure"
+
+        with (
+            patch("utils.subprocess.run", side_effect=error),
+            pytest.raises(InternalServerError),
+        ):
+            download_git_repo_module(
+                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
+            )
+
+        assert "ghp_secret" not in caplog.text

--- a/dashboard/api/tests/unit/test_git_module_checkout.py
+++ b/dashboard/api/tests/unit/test_git_module_checkout.py
@@ -12,9 +12,6 @@ from werkzeug.exceptions import InternalServerError, NotFound
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-FIRST_CLONE_ATTEMPT = 1
-SECOND_CLONE_COUNT = 2
-
 
 def _make_real_repo(repo_dir: Path, module_path: str, other_path: str) -> None:
     """Create a real local git repo with two module directories."""
@@ -45,15 +42,10 @@ class TestDownloadGitRepoModule:
 
         download_git_repo_module(str(repo), "gromacs/protein", target)
 
-        # Module contents are flattened into target (no module directory wrapper)
         assert (target / "notebook.ipynb").read_text() == "nb"
         assert (target / "gromacs.schema.json").read_text() == "{}"
-        # Other module and root files must NOT be present
         assert not (target / "other.ipynb").exists()
         assert not (target / "README.md").exists()
-        assert not (target / "amber").exists()
-        assert not (target / "gromacs").exists()
-        # No .git metadata
         assert not (target / ".git").exists()
 
     def test_missing_module_path_raises_not_found(self, tmp_path: Path) -> None:
@@ -61,26 +53,27 @@ class TestDownloadGitRepoModule:
         repo = tmp_path / "repo"
         _make_real_repo(repo, "gromacs/protein", "amber/protein")
 
-        target = tmp_path / "target"
-
         with pytest.raises(NotFound):
-            download_git_repo_module(str(repo), "does/not/exist", target)
+            download_git_repo_module(str(repo), "does/not/exist", tmp_path / "target")
 
-    def test_clone_failure_raises_internal_server_error(self, tmp_path: Path) -> None:
-        """A git clone failure should raise InternalServerError without leaking credentials."""
+    def test_clone_failure_redacts_token_from_errors_and_logs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Clone failures must not leak the access token in exceptions or logs."""
         target = tmp_path / "target"
         error = subprocess.CalledProcessError(1, "git")
-        error.stderr = "fatal: repository not found"
+        error.stderr = "fatal: auth failure"
 
         with (
             patch("utils.subprocess.run", side_effect=error),
             pytest.raises(InternalServerError) as exc_info,
         ):
             download_git_repo_module(
-                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="secret-token"
+                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
             )
 
-        assert "secret-token" not in str(exc_info.value)
+        assert "ghp_secret" not in str(exc_info.value)
+        assert "ghp_secret" not in caplog.text
 
     def test_clone_timeout_raises_internal_server_error(self, tmp_path: Path) -> None:
         """A clone timeout should raise InternalServerError."""
@@ -99,7 +92,6 @@ class TestDownloadGitRepoModule:
         target = tmp_path / "target"
 
         captured: list[list[str]] = []
-
         real_run = cast("Callable[..., subprocess.CompletedProcess[str]]", subprocess.run)
 
         def _capture(cmd: list[str] | str, *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -128,44 +120,12 @@ class TestDownloadGitRepoModule:
         def _flaky_clone(cmd: list[str] | str, *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
             if isinstance(cmd, list) and cmd[:1] == ["git"] and cmd[1:2] == ["clone"]:
                 call_count["clone"] += 1
-                if call_count["clone"] == FIRST_CLONE_ATTEMPT:
+                if call_count["clone"] == 1:
                     raise subprocess.CalledProcessError(1, cmd, stderr="fatal: filter not supported")
             return original_run(cmd, *args, **kwargs)
 
         with patch("utils.subprocess.run", side_effect=_flaky_clone):
             download_git_repo_module(str(repo), "gromacs/protein", target)
 
-        assert call_count["clone"] == SECOND_CLONE_COUNT
+        assert call_count["clone"] == 2  # ruff:ignore[magic-value-comparison] — two clone attempts: filtered then fallback
         assert (target / "notebook.ipynb").exists()
-
-    def test_access_token_injected_for_https_url_not_in_error(self, tmp_path: Path) -> None:
-        """Tokens injected into HTTPS URLs must not appear in error messages."""
-        target = tmp_path / "target"
-        error = subprocess.CalledProcessError(1, "git")
-        error.stderr = "fatal: auth failure"
-
-        with (
-            patch("utils.subprocess.run", side_effect=error),
-            pytest.raises(InternalServerError) as exc_info,
-        ):
-            download_git_repo_module(
-                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
-            )
-
-        assert "ghp_secret" not in str(exc_info.value)
-
-    def test_access_token_not_logged_on_failure(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """The access token must never appear in log records when a clone fails."""
-        target = tmp_path / "target"
-        error = subprocess.CalledProcessError(1, "git")
-        error.stderr = "fatal: auth failure"
-
-        with (
-            patch("utils.subprocess.run", side_effect=error),
-            pytest.raises(InternalServerError),
-        ):
-            download_git_repo_module(
-                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
-            )
-
-        assert "ghp_secret" not in caplog.text

--- a/dashboard/api/tests/unit/test_git_module_checkout.py
+++ b/dashboard/api/tests/unit/test_git_module_checkout.py
@@ -129,3 +129,38 @@ class TestDownloadGitRepoModule:
 
         assert call_count["clone"] == 2  # ruff:ignore[magic-value-comparison] — two clone attempts: filtered then fallback
         assert (target / "notebook.ipynb").exists()
+
+    def test_clone_failure_redacts_token_echoed_in_stderr(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A token echoed by git in the failure URL must be redacted from errors and logs."""
+        target = tmp_path / "target"
+        # git echoes the authenticated URL (token as userinfo) when it cannot read a password.
+        leaked = "fatal: could not read Password for 'http://ghp_secret@github.com':"
+        error = subprocess.CalledProcessError(1, "git")
+        error.stderr = leaked
+
+        with (
+            patch("utils.subprocess.run", side_effect=error),
+            pytest.raises(InternalServerError) as exc_info,
+        ):
+            download_git_repo_module(
+                "https://github.com/owner/repo.git", "gromacs/protein", target, access_token="ghp_secret"
+            )
+
+        assert "ghp_secret" not in str(exc_info.value)
+        assert "ghp_secret" not in caplog.text
+        assert "***" in str(exc_info.value)
+
+    def test_clone_timeout_does_not_retry(self, tmp_path: Path) -> None:
+        """A clone timeout must surface immediately without a fallback re-clone."""
+        target = tmp_path / "target"
+
+        with (
+            patch("utils.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="git", timeout=1)) as mock_run,
+            pytest.raises(InternalServerError),
+        ):
+            download_git_repo_module("https://github.com/owner/repo.git", "gromacs/protein", target)
+
+        # Only the first (filtered) clone attempt runs; the timeout is not retried.
+        assert mock_run.call_count == 1

--- a/dashboard/api/tests/unit/test_notebook_modules.py
+++ b/dashboard/api/tests/unit/test_notebook_modules.py
@@ -94,16 +94,6 @@ class TestCatalogLookup:
         assert catalog.get_module_for_engine("gromacs-protein", "AMBER") is None
         assert catalog.get_module_for_engine("nope", "GMX") is None
 
-    def test_for_engine_filters_by_engine(self) -> None:
-        """for_engine should return only modules matching the engine."""
-        catalog = load_catalog()
-
-        gmx = catalog.for_engine("GMX")
-
-        assert all(m.engine == "GMX" for m in gmx)
-        assert any(m.id == "gromacs-protein" for m in gmx)
-        assert not any(m.engine == "AMBER" for m in gmx)
-
     def test_to_public_excludes_internal_paths_and_is_serializable(self) -> None:
         """to_public should expose display metadata without paths, and be JSON-serializable."""
         catalog = load_catalog()

--- a/dashboard/api/tests/unit/test_notebook_modules.py
+++ b/dashboard/api/tests/unit/test_notebook_modules.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from jsonschema import ValidationError
-from notebook_modules import SCHEMA_PATH, load_catalog
+from notebook_modules import load_catalog
 
 MIN_MODULE_COUNT = 2
 
@@ -30,13 +30,7 @@ class TestLoadCatalog:
         ids = {m.id for m in catalog}
         assert "gromacs-protein" in ids
         assert "amber-protein" in ids
-
-    def test_bundled_catalog_modules_have_display_fields_without_paths(self) -> None:
-        """Each bundled module exposes stable display metadata."""
-        catalog = load_catalog()
-
         for module in catalog:
-            assert module.id
             assert module.name
             assert module.engine in {"GMX", "AMBER"}
 
@@ -90,108 +84,57 @@ class TestLoadCatalog:
 class TestCatalogLookup:
     """Tests for resolving modules by ID and engine."""
 
-    def test_get_module_returns_matching_module(self) -> None:
-        """get_module should return the module with the given ID."""
+    def test_get_returns_matching_module_and_none_for_misses(self) -> None:
+        """Get returns the module for a known ID, None for unknown or engine mismatch."""
         catalog = load_catalog()
 
-        module = catalog.get("gromacs-protein")
-
-        assert module is not None
-        assert module.engine == "GMX"
-        assert module.path == "gromacs/protein"
-
-    def test_get_module_unknown_id_returns_none(self) -> None:
-        """get_module should return None for an unknown ID."""
-        catalog = load_catalog()
-
+        assert catalog.get("gromacs-protein") is not None
         assert catalog.get("does-not-exist") is None
-
-    def test_get_module_for_engine_returns_matching_module(self) -> None:
-        """get_module_for_engine should return a module matching both ID and engine."""
-        catalog = load_catalog()
-
-        module = catalog.get_module_for_engine("amber-protein", "AMBER")
-
-        assert module is not None
-        assert module.engine == "AMBER"
-
-    def test_get_module_for_engine_rejects_engine_mismatch(self) -> None:
-        """get_module_for_engine should return None when engine differs."""
-        catalog = load_catalog()
-
+        assert catalog.get_module_for_engine("gromacs-protein", "GMX") is not None
         assert catalog.get_module_for_engine("gromacs-protein", "AMBER") is None
-
-    def test_get_module_for_engine_unknown_id_returns_none(self) -> None:
-        """get_module_for_engine should return None for an unknown ID."""
-        catalog = load_catalog()
-
         assert catalog.get_module_for_engine("nope", "GMX") is None
 
-    def test_to_public_excludes_internal_paths(self) -> None:
-        """to_public should expose display metadata without internal Git paths."""
+    def test_for_engine_filters_by_engine(self) -> None:
+        """for_engine should return only modules matching the engine."""
+        catalog = load_catalog()
+
+        gmx = catalog.for_engine("GMX")
+
+        assert all(m.engine == "GMX" for m in gmx)
+        assert any(m.id == "gromacs-protein" for m in gmx)
+        assert not any(m.engine == "AMBER" for m in gmx)
+
+    def test_to_public_excludes_internal_paths_and_is_serializable(self) -> None:
+        """to_public should expose display metadata without paths, and be JSON-serializable."""
         catalog = load_catalog()
 
         public = catalog.to_public()
 
+        assert isinstance(public, list)
         for entry in public:
             assert "id" in entry
             assert "name" in entry
             assert "engine" in entry
             assert "path" not in entry
             assert "repository" not in entry
-
-    def test_to_public_returns_list_of_dicts(self) -> None:
-        """to_public should return a JSON-serializable list."""
-        catalog = load_catalog()
-
-        public = catalog.to_public()
-
-        assert isinstance(public, list)
-        assert len(public) >= MIN_MODULE_COUNT
-        # Must be JSON-serializable for the API endpoint
         json.dumps(public)
-
-    def test_load_catalog_caches_default_path(self) -> None:
-        """The bundled catalog is memoized, so repeated default loads share one instance."""
-        first = load_catalog()
-        second = load_catalog()
-
-        assert first is second
-
-
-class TestModulePathSafety:
-    """Tests for module path normalization and safety."""
-
-    def test_module_path_is_relative_posix(self) -> None:
-        """Module paths should be forward-slash relative paths."""
-        catalog = load_catalog()
-
-        for module in catalog:
-            assert not module.path.startswith("/")
-            assert "\\" not in module.path
-            assert ".." not in module.path.split("/")
 
 
 class TestRepositoryField:
     """Tests for the optional repository field and root-path (Binder) support."""
 
-    def test_bundled_modules_without_repository_default_to_none(self) -> None:
-        """Curated modules without an explicit repository should have repository=None."""
+    def test_bundled_modules_split_between_default_and_explicit_repos(self) -> None:
+        """Bundled catalog has modules with and without explicit repository URLs."""
         catalog = load_catalog()
 
-        default_repo_modules = [m for m in catalog if m.repository is None]
-        assert len(default_repo_modules) >= MIN_MODULE_COUNT
+        default_repo = [m for m in catalog if m.repository is None]
+        explicit_repo = [m for m in catalog if m.repository is not None]
+        assert len(default_repo) >= MIN_MODULE_COUNT
+        assert len(explicit_repo) >= 1
+        assert all(m.is_root for m in explicit_repo)
 
-    def test_bundled_repository_modules_present(self) -> None:
-        """At least one bundled module should use an explicit repository (Binder)."""
-        catalog = load_catalog()
-
-        repo_modules = [m for m in catalog if m.repository is not None]
-        assert len(repo_modules) >= 1
-        assert all(m.repository and m.is_root for m in repo_modules)
-
-    def test_repository_field_accepted(self, tmp_path: Path) -> None:
-        """A module with a repository field should load correctly."""
+    def test_repository_field_and_root_path_accepted(self, tmp_path: Path) -> None:
+        """A module with a repository field and path '.' should load as a root module."""
         catalog_file = tmp_path / "notebook-modules.json"
         catalog_file.write_text(
             json.dumps({
@@ -213,25 +156,3 @@ class TestRepositoryField:
         assert module is not None
         assert module.repository == "https://github.com/bioexcel/biobb_wf_md_setup_membrane.git"
         assert module.is_root is True
-
-    def test_root_path_allowed(self, tmp_path: Path) -> None:
-        """Path '.' should be accepted as the repository root."""
-        catalog_file = tmp_path / "notebook-modules.json"
-        catalog_file.write_text(
-            json.dumps({"modules": [{"id": "root-mod", "name": "Root", "engine": "GMX", "path": "."}]})
-        )
-
-        catalog = load_catalog(path=catalog_file)
-        module = catalog.get("root-mod")
-
-        assert module is not None
-        assert module.is_root is True
-
-
-class TestBundledSchemaSelfCheck:
-    """Ensure the bundled catalog passes its own schema."""
-
-    def test_bundled_schema_file_is_valid_json(self) -> None:
-        """The bundled schema file should be valid JSON."""
-        data = json.loads(SCHEMA_PATH.read_text())
-        assert data["title"] == "Notebook modules catalog"

--- a/dashboard/api/tests/unit/test_notebook_modules.py
+++ b/dashboard/api/tests/unit/test_notebook_modules.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from jsonschema import ValidationError
-from notebook_modules import SCHEMA_PATH, NotebookModule, load_catalog
+from notebook_modules import SCHEMA_PATH, load_catalog
 
 MIN_MODULE_COUNT = 2
 
@@ -171,24 +171,6 @@ class TestModulePathSafety:
             assert "\\" not in module.path
             assert ".." not in module.path.split("/")
 
-    def test_module_resolved_relative_to_dir(self, tmp_path: Path) -> None:
-        """resolve_path should produce a path inside the given base directory."""
-        module = NotebookModule(id="x", name="X", description=None, engine="GMX", path="gromacs/protein")
-
-        resolved = module.resolve_path(tmp_path)
-
-        assert resolved == tmp_path / "gromacs" / "protein"
-        resolved.relative_to(tmp_path)
-
-    def test_module_to_dict_includes_path(self) -> None:
-        """The internal module representation includes the path for server-side use."""
-        module = NotebookModule(id="x", name="X", description="d", engine="GMX", path="gromacs/protein")
-
-        data = module.to_dict()
-
-        assert data["path"] == "gromacs/protein"
-        assert data["engine"] == "GMX"
-
 
 class TestRepositoryField:
     """Tests for the optional repository field and root-path (Binder) support."""
@@ -244,24 +226,6 @@ class TestRepositoryField:
 
         assert module is not None
         assert module.is_root is True
-
-    def test_to_dict_includes_repository_when_present(self) -> None:
-        """to_dict should include repository when set."""
-        module = NotebookModule(
-            id="x", name="X", description=None, engine="GMX", path=".", repository="https://example.com/repo.git"
-        )
-
-        data = module.to_dict()
-
-        assert data["repository"] == "https://example.com/repo.git"
-
-    def test_to_dict_omits_repository_when_absent(self) -> None:
-        """to_dict should not include repository when not set."""
-        module = NotebookModule(id="x", name="X", description=None, engine="GMX", path="gromacs/protein")
-
-        data = module.to_dict()
-
-        assert "repository" not in data
 
 
 class TestBundledSchemaSelfCheck:

--- a/dashboard/api/tests/unit/test_notebook_modules.py
+++ b/dashboard/api/tests/unit/test_notebook_modules.py
@@ -1,0 +1,273 @@
+"""Unit tests for the curated notebook modules catalog."""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+from notebook_modules import SCHEMA_PATH, NotebookModule, load_catalog
+
+MIN_MODULE_COUNT = 2
+
+
+def _catalog_json(modules: list[dict]) -> str:
+    """
+    Serialize a minimal catalog document with the given modules list.
+
+    Returns:
+        A JSON string with only the ``modules`` key set.
+    """
+    return json.dumps({"modules": modules})
+
+
+class TestLoadCatalog:
+    """Tests for load_catalog (bundled catalog loading and validation)."""
+
+    def test_loads_bundled_catalog_and_returns_modules(self) -> None:
+        """The bundled catalog should load and yield the curated protein modules."""
+        catalog = load_catalog()
+
+        ids = {m.id for m in catalog}
+        assert "gromacs-protein" in ids
+        assert "amber-protein" in ids
+
+    def test_bundled_catalog_modules_have_display_fields_without_paths(self) -> None:
+        """Each bundled module exposes stable display metadata."""
+        catalog = load_catalog()
+
+        for module in catalog:
+            assert module.id
+            assert module.name
+            assert module.engine in {"GMX", "AMBER"}
+
+    def test_unknown_property_rejected(self, tmp_path: Path) -> None:
+        """An unknown top-level property should fail validation."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(json.dumps({"modules": [], "unknown_field": True}))
+
+        with pytest.raises(ValidationError):
+            load_catalog(path=catalog_file)
+
+    def test_duplicate_module_ids_rejected(self, tmp_path: Path) -> None:
+        """Duplicate module IDs should fail validation."""
+        module = {"id": "dup", "name": "Dup", "engine": "GMX", "path": "gromacs/dup"}
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(_catalog_json([module, module]))
+
+        with pytest.raises(ValueError, match=r"(?i)duplicate"):
+            load_catalog(path=catalog_file)
+
+    def test_unknown_engine_rejected(self, tmp_path: Path) -> None:
+        """An engine outside the allowed enum should fail validation."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(_catalog_json([{"id": "x", "name": "X", "engine": "NAMD", "path": "x/y"}]))
+
+        with pytest.raises(ValidationError):
+            load_catalog(path=catalog_file)
+
+    def test_unsafe_path_rejected(self, tmp_path: Path) -> None:
+        """A path containing traversal or leading slash should fail validation."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(_catalog_json([{"id": "x", "name": "X", "engine": "GMX", "path": "../escape"}]))
+
+        with pytest.raises(ValidationError):
+            load_catalog(path=catalog_file)
+
+    def test_empty_modules_rejected(self, tmp_path: Path) -> None:
+        """An empty modules list should fail validation."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(_catalog_json([]))
+
+        with pytest.raises(ValidationError):
+            load_catalog(path=catalog_file)
+
+    def test_missing_catalog_file_raises(self, tmp_path: Path) -> None:
+        """A missing catalog file should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_catalog(path=tmp_path / "missing.json")
+
+
+class TestCatalogLookup:
+    """Tests for resolving modules by ID and engine."""
+
+    def test_get_module_returns_matching_module(self) -> None:
+        """get_module should return the module with the given ID."""
+        catalog = load_catalog()
+
+        module = catalog.get("gromacs-protein")
+
+        assert module is not None
+        assert module.engine == "GMX"
+        assert module.path == "gromacs/protein"
+
+    def test_get_module_unknown_id_returns_none(self) -> None:
+        """get_module should return None for an unknown ID."""
+        catalog = load_catalog()
+
+        assert catalog.get("does-not-exist") is None
+
+    def test_get_module_for_engine_returns_matching_module(self) -> None:
+        """get_module_for_engine should return a module matching both ID and engine."""
+        catalog = load_catalog()
+
+        module = catalog.get_module_for_engine("amber-protein", "AMBER")
+
+        assert module is not None
+        assert module.engine == "AMBER"
+
+    def test_get_module_for_engine_rejects_engine_mismatch(self) -> None:
+        """get_module_for_engine should return None when engine differs."""
+        catalog = load_catalog()
+
+        assert catalog.get_module_for_engine("gromacs-protein", "AMBER") is None
+
+    def test_get_module_for_engine_unknown_id_returns_none(self) -> None:
+        """get_module_for_engine should return None for an unknown ID."""
+        catalog = load_catalog()
+
+        assert catalog.get_module_for_engine("nope", "GMX") is None
+
+    def test_to_public_excludes_internal_paths(self) -> None:
+        """to_public should expose display metadata without internal Git paths."""
+        catalog = load_catalog()
+
+        public = catalog.to_public()
+
+        for entry in public:
+            assert "id" in entry
+            assert "name" in entry
+            assert "engine" in entry
+            assert "path" not in entry
+            assert "repository" not in entry
+
+    def test_to_public_returns_list_of_dicts(self) -> None:
+        """to_public should return a JSON-serializable list."""
+        catalog = load_catalog()
+
+        public = catalog.to_public()
+
+        assert isinstance(public, list)
+        assert len(public) >= MIN_MODULE_COUNT
+        # Must be JSON-serializable for the API endpoint
+        json.dumps(public)
+
+    def test_load_catalog_caches_default_path(self) -> None:
+        """The bundled catalog is memoized, so repeated default loads share one instance."""
+        first = load_catalog()
+        second = load_catalog()
+
+        assert first is second
+
+
+class TestModulePathSafety:
+    """Tests for module path normalization and safety."""
+
+    def test_module_path_is_relative_posix(self) -> None:
+        """Module paths should be forward-slash relative paths."""
+        catalog = load_catalog()
+
+        for module in catalog:
+            assert not module.path.startswith("/")
+            assert "\\" not in module.path
+            assert ".." not in module.path.split("/")
+
+    def test_module_resolved_relative_to_dir(self, tmp_path: Path) -> None:
+        """resolve_path should produce a path inside the given base directory."""
+        module = NotebookModule(id="x", name="X", description=None, engine="GMX", path="gromacs/protein")
+
+        resolved = module.resolve_path(tmp_path)
+
+        assert resolved == tmp_path / "gromacs" / "protein"
+        resolved.relative_to(tmp_path)
+
+    def test_module_to_dict_includes_path(self) -> None:
+        """The internal module representation includes the path for server-side use."""
+        module = NotebookModule(id="x", name="X", description="d", engine="GMX", path="gromacs/protein")
+
+        data = module.to_dict()
+
+        assert data["path"] == "gromacs/protein"
+        assert data["engine"] == "GMX"
+
+
+class TestRepositoryField:
+    """Tests for the optional repository field and root-path (Binder) support."""
+
+    def test_bundled_modules_without_repository_default_to_none(self) -> None:
+        """Curated modules without an explicit repository should have repository=None."""
+        catalog = load_catalog()
+
+        default_repo_modules = [m for m in catalog if m.repository is None]
+        assert len(default_repo_modules) >= MIN_MODULE_COUNT
+
+    def test_bundled_repository_modules_present(self) -> None:
+        """At least one bundled module should use an explicit repository (Binder)."""
+        catalog = load_catalog()
+
+        repo_modules = [m for m in catalog if m.repository is not None]
+        assert len(repo_modules) >= 1
+        assert all(m.repository and m.is_root for m in repo_modules)
+
+    def test_repository_field_accepted(self, tmp_path: Path) -> None:
+        """A module with a repository field should load correctly."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(
+            json.dumps({
+                "modules": [
+                    {
+                        "id": "binder-gmx",
+                        "name": "Binder",
+                        "engine": "GMX",
+                        "path": ".",
+                        "repository": "https://github.com/bioexcel/biobb_wf_md_setup_membrane.git",
+                    }
+                ]
+            })
+        )
+
+        catalog = load_catalog(path=catalog_file)
+        module = catalog.get("binder-gmx")
+
+        assert module is not None
+        assert module.repository == "https://github.com/bioexcel/biobb_wf_md_setup_membrane.git"
+        assert module.is_root is True
+
+    def test_root_path_allowed(self, tmp_path: Path) -> None:
+        """Path '.' should be accepted as the repository root."""
+        catalog_file = tmp_path / "notebook-modules.json"
+        catalog_file.write_text(
+            json.dumps({"modules": [{"id": "root-mod", "name": "Root", "engine": "GMX", "path": "."}]})
+        )
+
+        catalog = load_catalog(path=catalog_file)
+        module = catalog.get("root-mod")
+
+        assert module is not None
+        assert module.is_root is True
+
+    def test_to_dict_includes_repository_when_present(self) -> None:
+        """to_dict should include repository when set."""
+        module = NotebookModule(
+            id="x", name="X", description=None, engine="GMX", path=".", repository="https://example.com/repo.git"
+        )
+
+        data = module.to_dict()
+
+        assert data["repository"] == "https://example.com/repo.git"
+
+    def test_to_dict_omits_repository_when_absent(self) -> None:
+        """to_dict should not include repository when not set."""
+        module = NotebookModule(id="x", name="X", description=None, engine="GMX", path="gromacs/protein")
+
+        data = module.to_dict()
+
+        assert "repository" not in data
+
+
+class TestBundledSchemaSelfCheck:
+    """Ensure the bundled catalog passes its own schema."""
+
+    def test_bundled_schema_file_is_valid_json(self) -> None:
+        """The bundled schema file should be valid JSON."""
+        data = json.loads(SCHEMA_PATH.read_text())
+        assert data["title"] == "Notebook modules catalog"

--- a/dashboard/api/utils.py
+++ b/dashboard/api/utils.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-from werkzeug.exceptions import InternalServerError
+from werkzeug.exceptions import InternalServerError, NotFound
 
 logger = logging.getLogger(__name__)
 
@@ -294,50 +294,140 @@ def download_git_repo(git_url: str, target_dir: Path, access_token: str | None =
         target_dir: Directory to download files to.
         access_token: Optional access token for private HTTPS repositories.
                       Not applicable to SSH URLs (git@...).
-
-    Raises:
-        InternalServerError: If git clone fails.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
+    clone_url = _inject_token(git_url, access_token)
 
-    # Inject token into HTTPS URLs
-    clone_url = git_url
-    if access_token and not git_url.startswith("git@"):
-        # Parse and reconstruct URL with token
-        parsed = urlparse(git_url)
-        if parsed.scheme in {"http", "https"}:
-            # Construct authenticated URL: https://token@host/path
-            netloc_with_token = f"{access_token}@{parsed.netloc}"
-            clone_url = parsed._replace(netloc=netloc_with_token).geturl()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        clone_dir = Path(tmp_dir) / "repo"
+        _git(
+            ["clone", "--depth", "1", "--single-branch", "--no-tags", "--", clone_url, str(clone_dir)],
+            label="clone",
+        )
+
+        git_dir = clone_dir / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir)
+
+        for item in clone_dir.iterdir():
+            dest = target_dir / item.name
+            if dest.exists():
+                shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+            shutil.move(item, dest)
+
+        logger.info("Downloaded git repository from %s", git_url)
+
+
+def _inject_token(git_url: str, access_token: str | None) -> str:
+    """
+    Inject an access token into an HTTPS git URL, returning the clone URL.
+
+    Returns:
+        The git URL with the token embedded, or the original URL if no token applies.
+    """
+    if not access_token or git_url.startswith("git@"):
+        return git_url
+    parsed = urlparse(git_url)
+    if parsed.scheme not in {"http", "https"}:
+        return git_url
+    netloc_with_token = f"{access_token}@{parsed.netloc}"
+    return parsed._replace(netloc=netloc_with_token).geturl()
+
+
+def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation") -> None:
+    """
+    Run a git subprocess, raising InternalServerError on failure.
+
+    Only ``label`` and the captured ``stderr`` are logged; the raw ``args``
+    (which may contain a token-bearing URL) are never logged.
+
+    Args:
+        args: Git command arguments (without the leading ``git``).
+        cwd: Optional working directory for the git command.
+        label: Short, non-sensitive operation name used in logs and errors.
+
+    Raises:
+        InternalServerError: If the git command fails or times out.
+    """
+    try:
+        subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=GIT_CLONE_TIMEOUT,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip() if isinstance(e.stderr, str) else str(e).strip()
+        logger.error("Git %s failed: %s", label, stderr or str(e))
+        raise InternalServerError(description=f"Git {label} failed: {stderr or 'git operation failed'}") from e
+    except subprocess.TimeoutExpired as e:
+        raise InternalServerError(description=f"Git {label} timed out after {GIT_CLONE_TIMEOUT}s") from e
+
+
+def download_git_repo_module(git_url: str, module_path: str, target_dir: Path, access_token: str | None = None) -> None:
+    """
+    Check out a single module subdirectory from a git repository.
+
+    Perform a shallow partial clone with blob filtering and sparse-check out
+    only ``module_path``. The directory's *contents* (not the directory itself)
+    are copied into ``target_dir``. No ``.git`` metadata remains.
+
+    Fall back to a normal shallow clone when the server does not support blob
+    filtering, but still copy only the selected module.
+
+    Args:
+        git_url: Git repository URL to clone.
+        module_path: Repository-relative directory path to check out.
+        target_dir: Directory to copy the module contents into.
+        access_token: Optional access token for private HTTPS repositories.
+
+    Raises:
+        NotFound: If the module path does not exist in the repository.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    clone_url = _inject_token(git_url, access_token)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         clone_dir = Path(tmp_dir) / "repo"
 
         try:
-            subprocess.run(
-                ["git", "clone", "--depth", "1", "--single-branch", "--no-tags", "--", clone_url, str(clone_dir)],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=GIT_CLONE_TIMEOUT,
+            _git(
+                [
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--single-branch",
+                    "--no-tags",
+                    "--no-checkout",
+                    "--filter=blob:none",
+                    "--",
+                    clone_url,
+                    str(clone_dir),
+                ],
+                label="clone",
+            )
+        except InternalServerError:
+            # Server may not support partial clone; retry with a normal shallow clone.
+            _git(
+                ["clone", "--depth", "1", "--single-branch", "--no-tags", "--", clone_url, str(clone_dir)],
+                label="clone",
             )
 
-            git_dir = clone_dir / ".git"
-            if git_dir.exists():
-                shutil.rmtree(git_dir)
+        # Configure sparse checkout for the selected module directory.
+        _git(["sparse-checkout", "init", "--no-cone"], cwd=clone_dir, label="sparse-checkout init")
+        _git(["sparse-checkout", "set", module_path], cwd=clone_dir, label="sparse-checkout set")
+        _git(["checkout"], cwd=clone_dir, label="checkout")
 
-            for item in clone_dir.iterdir():
-                dest = target_dir / item.name
-                if dest.exists():
-                    shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
-                shutil.move(item, dest)
+        module_dir = clone_dir / module_path
+        if not module_dir.is_dir():
+            raise NotFound(description=f"Notebook module path '{module_path}' not found in repository.")
 
-            logger.info("Downloaded git repository from %s", git_url)
+        for item in module_dir.iterdir():
+            dest = target_dir / item.name
+            if dest.exists():
+                shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+            shutil.move(str(item), str(dest))
 
-        except subprocess.CalledProcessError as e:
-            stderr = (e.stderr or "").strip() if isinstance(e.stderr, str) else str(e).strip()
-            logger.error("Git clone failed: %s", stderr or str(e))
-            raise InternalServerError(description=f"Failed to clone repository: {stderr or 'git clone failed'}")
-
-        except subprocess.TimeoutExpired:
-            raise InternalServerError(description=f"Git clone timed out after {GIT_CLONE_TIMEOUT}s")
+        logger.info("Downloaded notebook module '%s' from %s", module_path, git_url)

--- a/dashboard/api/utils.py
+++ b/dashboard/api/utils.py
@@ -284,16 +284,10 @@ GIT_CLONE_TIMEOUT = 120
 
 def download_git_repo(git_url: str, target_dir: Path, access_token: str | None = None) -> None:
     """
-    Download files from a git repository without history.
+    Shallow-clone a git repository into ``target_dir`` without history.
 
-    Files are placed directly in target_dir (no subdirectory, no .git folder).
-    Caller is responsible for validating the URL before calling this function.
-
-    Args:
-        git_url: Git repository URL to clone.
-        target_dir: Directory to download files to.
-        access_token: Optional access token for private HTTPS repositories.
-                      Not applicable to SSH URLs (git@...).
+    The caller is responsible for validating the URL. Files are placed directly
+    in ``target_dir`` (no subdirectory, no ``.git`` folder).
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     clone_url = _inject_token(git_url, access_token)
@@ -320,7 +314,7 @@ def download_git_repo(git_url: str, target_dir: Path, access_token: str | None =
 
 def _inject_token(git_url: str, access_token: str | None) -> str:
     """
-    Inject an access token into an HTTPS git URL, returning the clone URL.
+    Inject an access token into an HTTPS git URL for cloning.
 
     Returns:
         The git URL with the token embedded, or the original URL if no token applies.
@@ -330,21 +324,12 @@ def _inject_token(git_url: str, access_token: str | None) -> str:
     parsed = urlparse(git_url)
     if parsed.scheme not in {"http", "https"}:
         return git_url
-    netloc_with_token = f"{access_token}@{parsed.netloc}"
-    return parsed._replace(netloc=netloc_with_token).geturl()
+    return parsed._replace(netloc=f"{access_token}@{parsed.netloc}").geturl()
 
 
 def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation") -> None:
     """
-    Run a git subprocess, raising InternalServerError on failure.
-
-    Only ``label`` and the captured ``stderr`` are logged; the raw ``args``
-    (which may contain a token-bearing URL) are never logged.
-
-    Args:
-        args: Git command arguments (without the leading ``git``).
-        cwd: Optional working directory for the git command.
-        label: Short, non-sensitive operation name used in logs and errors.
+    Run a git subprocess. Only ``label`` and stderr are logged; args may contain tokens.
 
     Raises:
         InternalServerError: If the git command fails or times out.
@@ -368,23 +353,13 @@ def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation") 
 
 def download_git_repo_module(git_url: str, module_path: str, target_dir: Path, access_token: str | None = None) -> None:
     """
-    Check out a single module subdirectory from a git repository.
+    Sparse-checkout a single module subdirectory from a git repository.
 
-    Perform a shallow partial clone with blob filtering and sparse-check out
-    only ``module_path``. The directory's *contents* (not the directory itself)
-    are copied into ``target_dir``. No ``.git`` metadata remains.
-
-    Fall back to a normal shallow clone when the server does not support blob
-    filtering, but still copy only the selected module.
-
-    Args:
-        git_url: Git repository URL to clone.
-        module_path: Repository-relative directory path to check out.
-        target_dir: Directory to copy the module contents into.
-        access_token: Optional access token for private HTTPS repositories.
+    Copies the directory's *contents* (not the directory itself) into ``target_dir``.
+    Falls back to a normal shallow clone if the server doesn't support blob filtering.
 
     Raises:
-        NotFound: If the module path does not exist in the repository.
+        NotFound: If ``module_path`` does not exist in the repository.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     clone_url = _inject_token(git_url, access_token)

--- a/dashboard/api/utils.py
+++ b/dashboard/api/utils.py
@@ -2,6 +2,7 @@ import fnmatch
 import logging
 import os
 import random
+import re
 import shutil
 import subprocess
 import tempfile
@@ -281,14 +282,12 @@ def start_du_monitor(data_dir: Path, initial_delay: float = 0.0) -> None:
 # Timeout for git clone operations (seconds)
 GIT_CLONE_TIMEOUT = 120
 
+# Matches the ``://userinfo@`` segment of a URL so captured git stderr can be scrubbed.
+_URL_USERINFO_RE = re.compile(r"(://)[^@\s/]+(@)")
+
 
 def download_git_repo(git_url: str, target_dir: Path, access_token: str | None = None) -> None:
-    """
-    Shallow-clone a git repository into ``target_dir`` without history.
-
-    The caller is responsible for validating the URL. Files are placed directly
-    in ``target_dir`` (no subdirectory, no ``.git`` folder).
-    """
+    """Shallow-clone a git repository into ``target_dir`` (no subdirectory, no ``.git``)."""
     target_dir.mkdir(parents=True, exist_ok=True)
     clone_url = _inject_token(git_url, access_token)
 
@@ -297,17 +296,14 @@ def download_git_repo(git_url: str, target_dir: Path, access_token: str | None =
         _git(
             ["clone", "--depth", "1", "--single-branch", "--no-tags", "--", clone_url, str(clone_dir)],
             label="clone",
+            secret=access_token,
         )
 
         git_dir = clone_dir / ".git"
         if git_dir.exists():
             shutil.rmtree(git_dir)
 
-        for item in clone_dir.iterdir():
-            dest = target_dir / item.name
-            if dest.exists():
-                shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
-            shutil.move(item, dest)
+        _move_contents(clone_dir, target_dir)
 
         logger.info("Downloaded git repository from %s", git_url)
 
@@ -317,7 +313,7 @@ def _inject_token(git_url: str, access_token: str | None) -> str:
     Inject an access token into an HTTPS git URL for cloning.
 
     Returns:
-        The git URL with the token embedded, or the original URL if no token applies.
+        The URL with the token embedded, or the original URL if no token applies.
     """
     if not access_token or git_url.startswith("git@"):
         return git_url
@@ -327,9 +323,23 @@ def _inject_token(git_url: str, access_token: str | None) -> str:
     return parsed._replace(netloc=f"{access_token}@{parsed.netloc}").geturl()
 
 
-def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation") -> None:
+def _redact(text: str | None, secret: str | None) -> str:
     """
-    Run a git subprocess. Only ``label`` and stderr are logged; args may contain tokens.
+    Strip the literal secret and any ``://userinfo@`` segment from git output.
+
+    Returns:
+        The scrubbed text.
+    """
+    if not text:
+        return ""
+    if secret:
+        text = text.replace(secret, "***")
+    return _URL_USERINFO_RE.sub(r"\1***\2", text)
+
+
+def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation", secret: str | None = None) -> None:
+    """
+    Run a git subprocess, logging only the redacted stderr.
 
     Raises:
         InternalServerError: If the git command fails or times out.
@@ -344,22 +354,59 @@ def _git(args: list[str], *, cwd: Path | None = None, label: str = "operation") 
             timeout=GIT_CLONE_TIMEOUT,
         )
     except subprocess.CalledProcessError as e:
-        stderr = (e.stderr or "").strip() if isinstance(e.stderr, str) else str(e).strip()
-        logger.error("Git %s failed: %s", label, stderr or str(e))
-        raise InternalServerError(description=f"Git {label} failed: {stderr or 'git operation failed'}") from e
+        raw = e.stderr if isinstance(e.stderr, str) else ""
+        detail = _redact((raw or str(e)).strip(), secret)
+        logger.error("Git %s failed: %s", label, detail or "git operation failed")
+        raise InternalServerError(description=f"Git {label} failed: {detail or 'git operation failed'}") from e
     except subprocess.TimeoutExpired as e:
         raise InternalServerError(description=f"Git {label} timed out after {GIT_CLONE_TIMEOUT}s") from e
 
 
+def _is_partial_clone_unsupported(exc: BaseException) -> bool:
+    """
+    Return True when the clone failed because the server rejects partial-clone filtering.
+
+    Returns:
+        True for partial-clone failures, False for timeouts/auth/network errors.
+    """
+    cause = exc.__cause__
+    if not isinstance(cause, subprocess.CalledProcessError):
+        return False
+    stderr = cause.stderr if isinstance(cause.stderr, str) else ""
+    text = stderr.lower()
+    return "filter" in text or "partial" in text
+
+
+def _is_outside(path: Path, base: Path) -> bool:
+    """
+    Return True when ``path`` resolves outside ``base`` (e.g. a symlink escape).
+
+    Returns:
+        True if the path escapes the base directory.
+    """
+    try:
+        path.resolve().relative_to(base.resolve())
+    except ValueError:
+        return True
+    return False
+
+
+def _move_contents(src_dir: Path, target_dir: Path) -> None:
+    """Move every entry of ``src_dir`` into ``target_dir``, replacing existing entries."""
+    for item in src_dir.iterdir():
+        dest = target_dir / item.name
+        if dest.exists():
+            shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+        shutil.move(item, dest)
+
+
 def download_git_repo_module(git_url: str, module_path: str, target_dir: Path, access_token: str | None = None) -> None:
     """
-    Sparse-checkout a single module subdirectory from a git repository.
-
-    Copies the directory's *contents* (not the directory itself) into ``target_dir``.
-    Falls back to a normal shallow clone if the server doesn't support blob filtering.
+    Sparse-checkout a single module subdirectory into ``target_dir``.
 
     Raises:
-        NotFound: If ``module_path`` does not exist in the repository.
+        NotFound: If ``module_path`` does not exist in the repository or escapes the clone.
+        InternalServerError: If a git operation fails or times out.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     clone_url = _inject_token(git_url, access_token)
@@ -382,27 +429,30 @@ def download_git_repo_module(git_url: str, module_path: str, target_dir: Path, a
                     str(clone_dir),
                 ],
                 label="clone",
+                secret=access_token,
             )
-        except InternalServerError:
-            # Server may not support partial clone; retry with a normal shallow clone.
+        except InternalServerError as exc:
+            # Retry only on partial-clone-unsupported; surface all other failures.
+            if not _is_partial_clone_unsupported(exc):
+                raise
+            shutil.rmtree(clone_dir, ignore_errors=True)
             _git(
                 ["clone", "--depth", "1", "--single-branch", "--no-tags", "--", clone_url, str(clone_dir)],
                 label="clone",
+                secret=access_token,
             )
 
         # Configure sparse checkout for the selected module directory.
-        _git(["sparse-checkout", "init", "--no-cone"], cwd=clone_dir, label="sparse-checkout init")
-        _git(["sparse-checkout", "set", module_path], cwd=clone_dir, label="sparse-checkout set")
-        _git(["checkout"], cwd=clone_dir, label="checkout")
+        _git(["sparse-checkout", "init", "--no-cone"], cwd=clone_dir, label="sparse-checkout init", secret=access_token)
+        _git(["sparse-checkout", "set", module_path], cwd=clone_dir, label="sparse-checkout set", secret=access_token)
+        _git(["checkout"], cwd=clone_dir, label="checkout", secret=access_token)
 
+        # Reject symlink/traversal escapes before copying (could move other tenants' data).
+        clone_root = clone_dir.resolve()
         module_dir = clone_dir / module_path
-        if not module_dir.is_dir():
+        if not module_dir.resolve().is_dir() or _is_outside(module_dir, clone_root):
             raise NotFound(description=f"Notebook module path '{module_path}' not found in repository.")
 
-        for item in module_dir.iterdir():
-            dest = target_dir / item.name
-            if dest.exists():
-                shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
-            shutil.move(str(item), str(dest))
+        _move_contents(module_dir, target_dir)
 
         logger.info("Downloaded notebook module '%s' from %s", module_path, git_url)

--- a/dashboard/api/validate_notebook_modules.py
+++ b/dashboard/api/validate_notebook_modules.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Deploy-time guard: verify catalog module paths exist as directories in their repos."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from subprocess import CalledProcessError, TimeoutExpired, run
+
+from config import DEFAULT_NOTEBOOKS_REPO
+from notebook_modules import load_catalog
+
+
+def _path_is_tree(repo_url: str, path: str, clone_dir: Path) -> bool:
+    """
+    Check whether ``path`` is a directory tree in the repo HEAD.
+
+    Returns:
+        True if the path is a tree object at HEAD.
+    """
+    run(
+        ["git", "clone", "--depth", "1", "--no-checkout", "--filter=blob:none", "--", repo_url, str(clone_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    result = run(
+        ["git", "cat-file", "-t", f"HEAD:{path}"],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "tree"
+
+
+def main() -> int:
+    catalog = load_catalog()
+    failures: list[str] = []
+
+    for module in catalog:
+        if module.is_root:
+            continue
+        repo_url = module.repository or DEFAULT_NOTEBOOKS_REPO
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                if not _path_is_tree(repo_url, module.path, Path(tmp)):
+                    failures.append(f"{module.id}: path '{module.path}' not a directory in {repo_url}")
+            except (CalledProcessError, TimeoutExpired) as exc:
+                failures.append(f"{module.id}: cannot probe {repo_url}: {exc}")
+
+    if failures:
+        for f in failures:
+            print(f"ERROR: {f}", file=sys.stderr)
+        return 1
+
+    non_root = [m for m in catalog if not m.is_root]
+    print(f"OK: {len(non_root)} module path(s) verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/ui/src/hooks/use-notebook-modules.ts
+++ b/dashboard/ui/src/hooks/use-notebook-modules.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/http"
+import type { NotebookModule } from "@/util/types"
+
+export function useNotebookModules() {
+  return useQuery<NotebookModule[]>({
+    queryKey: ["notebook-modules"],
+    queryFn: () => api.get("/notebook-modules").then((r) => r.data),
+  })
+}

--- a/dashboard/ui/src/pages/New.tsx
+++ b/dashboard/ui/src/pages/New.tsx
@@ -230,10 +230,9 @@ const New = () => {
             {type === "file" && <Dropzone inputName="simulation-files" onFilesChange={setFiles} />}
 
             <div className="flex flex-col gap-2">
-              <Label>Notebook Workflow</Label>
-
               {!useCustomRepo ? (
                 <div className="flex flex-col gap-2">
+                  <Label>Notebook Workflow</Label>
                   {modulesLoading && (
                     <p className="text-muted-foreground flex items-center gap-2 text-sm">
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -285,7 +284,7 @@ const New = () => {
               ) : (
                 <div className="flex flex-col gap-2">
                   <div className="flex flex-col gap-1">
-                    <Label htmlFor="notebooks-repo">Repository URL</Label>
+                    <Label htmlFor="notebooks-repo">Notebook Repository URL</Label>
                     <div className="flex gap-2">
                       <Input
                         id="notebooks-repo"

--- a/dashboard/ui/src/pages/New.tsx
+++ b/dashboard/ui/src/pages/New.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react"
 
 import { useNavigate } from "@tanstack/react-router"
-import { ChevronDown, ChevronUp, Loader2, RotateCcw } from "lucide-react"
+import { ArrowLeft, ChevronDown, ChevronUp, Loader2, RotateCcw, Settings2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { DEFAULT_NOTEBOOKS_REPO, Engine } from "@/util/const"
 import type { Engine as EngineType } from "@/util/const"
 import { useCreateExperiment } from "@/hooks/use-experiments"
+import { useNotebookModules } from "@/hooks/use-notebook-modules"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -33,6 +34,12 @@ const isValidGitUrl = (url: string): boolean => {
 const New = () => {
   const navigate = useNavigate()
   const createExperiment = useCreateExperiment()
+  const {
+    data: modules,
+    isLoading: modulesLoading,
+    isError: modulesError,
+    refetch: refetchModules,
+  } = useNotebookModules()
 
   const [name, setName] = useState("")
   const [engine, setEngine] = useState<EngineType>(Engine.GMX)
@@ -40,6 +47,8 @@ const New = () => {
   const [pdb, setPdb] = useState("")
   const [repoUrl, setRepoUrl] = useState("")
   const [files, setFiles] = useState<File[]>([])
+  const [selectedModuleId, setSelectedModuleId] = useState<string>("")
+  const [useCustomRepo, setUseCustomRepo] = useState(false)
   const [notebooksRepo, setNotebooksRepo] = useState(DEFAULT_NOTEBOOKS_REPO)
   const [accessToken, setAccessToken] = useState("")
   const [showTokenInput, setShowTokenInput] = useState(false)
@@ -48,8 +57,15 @@ const New = () => {
   const [typeError, setTypeError] = useState(false)
   const [typeAuxError, setTypeAuxError] = useState(false)
   const [notebooksRepoError, setNotebooksRepoError] = useState(false)
+  const [moduleError, setModuleError] = useState(false)
 
   const isHttpsRepo = notebooksRepo.startsWith("http://") || notebooksRepo.startsWith("https://")
+  const engineModules = (modules ?? []).filter((m) => m.engine === engine)
+
+  const handleEngineChange = (newEngine: EngineType) => {
+    setEngine(newEngine)
+    setSelectedModuleId("")
+  }
 
   const handleNotebooksRepoChange = (value: string) => {
     setNotebooksRepo(value)
@@ -60,9 +76,23 @@ const New = () => {
     }
   }
 
+  const handleUseCustomRepo = () => {
+    setUseCustomRepo(true)
+    setSelectedModuleId("")
+  }
+
+  const handleBackToCurated = () => {
+    setUseCustomRepo(false)
+    setNotebooksRepo(DEFAULT_NOTEBOOKS_REPO)
+    setAccessToken("")
+    setShowTokenInput(false)
+    setNotebooksRepoError(false)
+  }
+
   const validateForm = () => {
     let auxErr = false
-    const notebooksInvalid = !isValidGitUrl(notebooksRepo)
+    const notebooksInvalid = useCustomRepo && !isValidGitUrl(notebooksRepo)
+    const moduleMissing = !useCustomRepo && !selectedModuleId
 
     if ((type === "pdb" && !pdb) || (type === "repo" && !repoUrl) || (type === "file" && files.length === 0))
       auxErr = true
@@ -71,8 +101,9 @@ const New = () => {
     setTypeError(!type)
     setTypeAuxError(auxErr)
     setNotebooksRepoError(notebooksInvalid)
+    setModuleError(moduleMissing)
 
-    if (name && type && !auxErr && !notebooksInvalid) return true
+    if (name && type && !auxErr && !notebooksInvalid && !moduleMissing) return true
 
     toast.error("Please fill in all required fields")
     return false
@@ -87,13 +118,18 @@ const New = () => {
     formData.append("experiment-name", name)
     formData.append("engine", engine)
     formData.append("type", type)
-    formData.append("notebooks-repo", notebooksRepo)
     if (type === "pdb") formData.append("pdb", pdb)
     if (type === "repo") formData.append("repo-url", repoUrl)
     if (type === "file" && files.length > 0) {
       files.forEach((file) => formData.append("simulation-files", file))
     }
-    if (accessToken) formData.append("access-token", accessToken)
+
+    if (useCustomRepo) {
+      formData.append("notebooks-repo", notebooksRepo)
+      if (accessToken) formData.append("access-token", accessToken)
+    } else {
+      formData.append("notebook-module", selectedModuleId)
+    }
 
     createExperiment.mutate(formData, {
       onSuccess: (data) => {
@@ -130,7 +166,7 @@ const New = () => {
 
             <div className="flex flex-col gap-1">
               <Label>MD Engine</Label>
-              <Tabs value={engine} onValueChange={(v) => setEngine(v as EngineType)}>
+              <Tabs value={engine} onValueChange={(v) => handleEngineChange(v as EngineType)}>
                 <TabsList className="w-full">
                   <TabsTrigger value={Engine.GMX} className="flex-1">
                     GROMACS
@@ -194,65 +230,132 @@ const New = () => {
             {type === "file" && <Dropzone inputName="simulation-files" onFilesChange={setFiles} />}
 
             <div className="flex flex-col gap-2">
-              <div className="flex flex-col gap-1">
-                <Label htmlFor="notebooks-repo">Notebooks Repository</Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="notebooks-repo"
-                    value={notebooksRepo}
-                    onChange={(e) => handleNotebooksRepoChange(e.target.value)}
-                    className={notebooksRepoError ? "border-destructive flex-1" : "flex-1"}
-                  />
-                  {notebooksRepo !== DEFAULT_NOTEBOOKS_REPO && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="icon"
-                          onClick={() => handleNotebooksRepoChange(DEFAULT_NOTEBOOKS_REPO)}
-                          aria-label="Reset to default"
-                        >
-                          <RotateCcw className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Reset to default</TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-                <p className="text-muted-foreground text-xs">
-                  {notebooksRepoError
-                    ? "Enter a valid git repository"
-                    : "Git repository with notebooks. Supports Binder and standard repos."}
-                </p>
-              </div>
+              <Label>Notebook Workflow</Label>
 
-              {notebooksRepo !== DEFAULT_NOTEBOOKS_REPO && isHttpsRepo && (
-                <Collapsible open={showTokenInput} onOpenChange={setShowTokenInput}>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
-                    >
-                      {showTokenInput ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                      {showTokenInput ? "Hide access token" : "Provide access token"}
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="mt-2 flex flex-col gap-1">
-                    <Label htmlFor="access-token">Git Access Token</Label>
-                    <Input
-                      id="access-token"
-                      type="password"
-                      value={accessToken}
-                      onChange={(e) => setAccessToken(e.target.value)}
-                      placeholder="e.g. ghp_xxxxx, glpat_xxxxx, github_pat_xxxxx"
-                    />
-                    <p className="text-muted-foreground text-xs">
-                      Required for private HTTPS repositories. Not applicable for SSH URLs. Only used for cloning, not
-                      stored.
+              {!useCustomRepo ? (
+                <div className="flex flex-col gap-2">
+                  {modulesLoading && (
+                    <p className="text-muted-foreground flex items-center gap-2 text-sm">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading workflows...
                     </p>
-                  </CollapsibleContent>
-                </Collapsible>
+                  )}
+                  {modulesError && (
+                    <div className="flex flex-col gap-1">
+                      <p className="text-destructive text-xs">Failed to load workflows.</p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="self-start"
+                        onClick={() => refetchModules()}
+                      >
+                        Retry
+                      </Button>
+                    </div>
+                  )}
+                  {engineModules.map((m) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedModuleId(m.id)
+                        setModuleError(false)
+                      }}
+                      className={`hover:border-primary rounded-lg border p-3 text-left transition-colors ${
+                        selectedModuleId === m.id ? "border-primary bg-primary/5" : "border-border"
+                      } ${moduleError ? "border-destructive" : ""}`}
+                    >
+                      <span className="font-medium">{m.name}</span>
+                      {m.description && <span className="text-muted-foreground block text-xs">{m.description}</span>}
+                    </button>
+                  ))}
+                  {moduleError && <p className="text-destructive text-xs">Select a notebook workflow.</p>}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleUseCustomRepo}
+                    className="text-muted-foreground hover:text-foreground mt-1 self-start"
+                  >
+                    <Settings2 className="h-4 w-4" />
+                    Use custom notebooks repository
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-1">
+                    <Label htmlFor="notebooks-repo">Repository URL</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        id="notebooks-repo"
+                        value={notebooksRepo}
+                        onChange={(e) => handleNotebooksRepoChange(e.target.value)}
+                        className={notebooksRepoError ? "border-destructive flex-1" : "flex-1"}
+                      />
+                      {notebooksRepo !== DEFAULT_NOTEBOOKS_REPO && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              onClick={() => handleNotebooksRepoChange(DEFAULT_NOTEBOOKS_REPO)}
+                              aria-label="Reset to default"
+                            >
+                              <RotateCcw className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Reset to default</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      {notebooksRepoError
+                        ? "Enter a valid git repository"
+                        : "Git repository with notebooks. Supports Binder and standard repos."}
+                    </p>
+                  </div>
+
+                  {isHttpsRepo && (
+                    <Collapsible open={showTokenInput} onOpenChange={setShowTokenInput}>
+                      <CollapsibleTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
+                        >
+                          {showTokenInput ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                          {showTokenInput ? "Hide access token" : "Provide access token"}
+                        </button>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="mt-2 flex flex-col gap-1">
+                        <Label htmlFor="access-token">Git Access Token</Label>
+                        <Input
+                          id="access-token"
+                          type="password"
+                          value={accessToken}
+                          onChange={(e) => setAccessToken(e.target.value)}
+                          placeholder="e.g. ghp_xxxxx, glpat_xxxxx, github_pat_xxxxx"
+                        />
+                        <p className="text-muted-foreground text-xs">
+                          Required for private HTTPS repositories. Not applicable for SSH URLs. Only used for cloning,
+                          not stored.
+                        </p>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  )}
+
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleBackToCurated}
+                    className="text-muted-foreground hover:text-foreground mt-1 self-start"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                    Back to curated workflows
+                  </Button>
+                </div>
               )}
             </div>
 

--- a/dashboard/ui/src/util/types.ts
+++ b/dashboard/ui/src/util/types.ts
@@ -1,5 +1,12 @@
 import type { Engine } from "./const"
 
+export interface NotebookModule {
+  id: string
+  name: string
+  description: string
+  engine: Engine
+}
+
 export interface Experiment {
   id: string
   created_at: string

--- a/docs/superpowers/specs/2026-07-23-curated-notebook-modules-design.md
+++ b/docs/superpowers/specs/2026-07-23-curated-notebook-modules-design.md
@@ -2,16 +2,9 @@
 
 ## Summary
 
-MDDash will present curated notebook modules from the configured default
-notebooks repository. Users choose an MD engine and then choose a compatible
-module, such as the GROMACS protein workflow. MDDash checks out only that
-module's directory and copies its contents into the experiment root.
+MDDash will present curated notebook modules from the configured default notebooks repository. Users choose an MD engine and then choose a compatible module, such as the GROMACS protein workflow. MDDash checks out only that module's directory and copies its contents into the experiment root.
 
-The repository URL is not displayed in the normal creation flow. Users can
-choose a secondary custom-repository flow when they need their own Git or
-Binder-compatible repository. Custom repositories retain the current behavior:
-MDDash clones the complete default branch and copies the repository root into
-the experiment.
+The repository URL is not displayed in the normal creation flow. Users can choose a secondary custom-repository flow when they need their own Git or Binder-compatible repository. Custom repositories retain the current behavior: MDDash clones the complete default branch and copies the repository root into the experiment.
 
 ## Goals
 
@@ -33,15 +26,11 @@ the experiment.
 - Runtime operator overrides of the curated module catalog.
 - Updating notebook content after experiment creation.
 
-Custom repositories may continue to contain Binder configuration. The existing
-notebook startup behavior remains responsible for using it.
+Custom repositories may continue to contain Binder configuration. The existing notebook startup behavior remains responsible for using it.
 
 ## Current State
 
-Experiment creation currently accepts an always-visible notebooks repository
-URL. The API shallow-clones the remote default branch, removes `.git`, and moves
-all repository-root content into the experiment directory. The selected engine
-does not affect the clone.
+Experiment creation currently accepts an always-visible notebooks repository URL. The API shallow-clones the remote default branch, removes `.git`, and moves all repository-root content into the experiment directory. The selected engine does not affect the clone.
 
 The current `mddash-notebooks` default branch contains seven root-level files:
 
@@ -57,14 +46,10 @@ protein-setup.ipynb
 
 The files form two self-contained groups:
 
-- GROMACS protein: `protein-setup.ipynb`, `protein-analysis.ipynb`,
-  `mdanalysis_utils.py`, and `gromacs.schema.json`.
-- AMBER protein: `amber-protein-setup.ipynb`, `amber_wrapper.py`, and
-  `amber.schema.json`.
+- GROMACS protein: `protein-setup.ipynb`, `protein-analysis.ipynb`, `mdanalysis_utils.py`, and `gromacs.schema.json`.
+- AMBER protein: `amber-protein-setup.ipynb`, `amber_wrapper.py`, and `amber.schema.json`.
 
-The repository has no Binder configuration. Both setup notebooks expect
-`input.pdb` and write their simulation manifest and generated directories
-relative to the experiment root.
+The repository has no Binder configuration. Both setup notebooks expect `input.pdb` and write their simulation manifest and generated directories relative to the experiment root.
 
 ## Curated Repository Layout
 
@@ -85,22 +70,13 @@ amber/
     amber.schema.json
 ```
 
-Future modules use the same engine/module shape, for example
-`gromacs/membrane/` or `amber/protein-ligand/`. The shape is a first-party
-organization convention, not a discovery contract for custom repositories.
+Future modules use the same engine/module shape, for example `gromacs/membrane/` or `amber/protein-ligand/`. The shape is a first-party organization convention, not a discovery contract for custom repositories.
 
-Each module must be self-contained. Notebooks, local Python helpers, schemas,
-and optional environment or Binder files required by that workflow live inside
-the module directory. MDDash copies the directory's contents, not the directory
-itself, into the experiment root. This preserves the current assumptions about
-`input.pdb`, local imports, schema paths, and generated simulation files.
+Each module must be self-contained. Notebooks, local Python helpers, schemas, and optional environment or Binder files required by that workflow live inside the module directory. MDDash copies the directory's contents, not the directory itself, into the experiment root. This preserves the current assumptions about `input.pdb`, local imports, schema paths, and generated simulation files.
 
 ## Module Catalog
 
-MDDash owns a versioned `notebook-modules.json` file bundled with the Dashboard
-API image. It is product content and is not part of runtime deployment
-configuration. The existing `defaultNotebooksRepo` setting remains the only
-operator-configurable part of the curated source.
+MDDash owns a versioned `notebook-modules.json` file bundled with the Dashboard API image. It is product content and is not part of runtime deployment configuration. The existing `defaultNotebooksRepo` setting remains the only operator-configurable part of the curated source.
 
 The initial catalog is equivalent to:
 
@@ -126,23 +102,11 @@ The initial catalog is equivalent to:
 }
 ```
 
-A JSON Schema stored in the MDDash repository validates the JSON catalog in CI
-and when the API starts. Validation requires a supported schema version, unique
-module IDs, non-empty display fields, a known engine, and a safe relative path.
-Paths may not be absolute or contain `..`, empty components, backslashes, or
-control characters. Invalid bundled product configuration is a startup error,
-not a recoverable user error.
+A JSON Schema stored in the MDDash repository validates the JSON catalog in CI and when the API starts. Validation requires a supported schema version, unique module IDs, non-empty display fields, a known engine, and a safe relative path. Paths may not be absolute or contain `..`, empty components, backslashes, or control characters. Invalid bundled product configuration is a startup error, not a recoverable user error.
 
-The API is the catalog's single source of truth. A read-only endpoint returns
-the display metadata required by the UI. It need not return repository URLs or
-paths. Experiment creation accepts a module ID, and the API resolves that ID to
-the server-side engine and path. It rejects a module whose engine differs from
-the submitted experiment engine.
+The API is the catalog's single source of truth. A read-only endpoint returns the display metadata required by the UI. It need not return repository URLs or paths. Experiment creation accepts a module ID, and the API resolves that ID to the server-side engine and path. It rejects a module whose engine differs from the submitted experiment engine.
 
-Changing `defaultNotebooksRepo` is supported, but the replacement repository
-must implement the paths in the bundled catalog. Installations needing a
-different curated catalog can introduce a runtime override in a future design;
-arbitrary user repositories use the custom flow instead.
+Changing `defaultNotebooksRepo` is supported, but the replacement repository must implement the paths in the bundled catalog. Installations needing a different curated catalog can introduce a runtime override in a future design; arbitrary user repositories use the custom flow instead.
 
 ## Creation UX
 
@@ -154,29 +118,17 @@ The normal creation form has this order:
 4. Notebook module selection.
 5. Create experiment.
 
-The module section fetches the bundled catalog through the API and shows only
-modules compatible with the selected engine. Modules are presented by name and
-description; internal Git paths are not shown. A module selection is required,
-including when only one compatible module currently exists. Changing engines
-clears an incompatible selection and displays the new engine's modules.
+The module section fetches the bundled catalog through the API and shows only modules compatible with the selected engine. Modules are presented by name and description; internal Git paths are not shown. A module selection is required, including when only one compatible module currently exists. Changing engines clears an incompatible selection and displays the new engine's modules.
 
-The repository input is absent from this default view. A secondary **Use custom
-notebooks repository** action switches the module section into custom mode and
-reveals the current repository URL and optional access-token controls. Custom
-mode retains the explicit engine selected above. It does not show module or
-subdirectory selection.
+The repository input is absent from this default view. A secondary **Use custom notebooks repository** action switches the module section into custom mode and reveals the current repository URL and optional access-token controls. Custom mode retains the explicit engine selected above. It does not show module or subdirectory selection.
 
-Switching back to curated modules clears the custom URL and token from form
-state. Tokens remain transient and are never persisted.
+Switching back to curated modules clears the custom URL and token from form state. Tokens remain transient and are never persisted.
 
-Loading the module catalog is independent of Git access and requires no
-repository probe. If catalog loading fails, creation is disabled and the UI
-offers a retry. Custom repository creation remains available.
+Loading the module catalog is independent of Git access and requires no repository probe. If catalog loading fails, creation is disabled and the UI offers a retry. Custom repository creation remains available.
 
 ## API And Clone Behavior
 
-Curated creation submits the selected module ID instead of a notebooks
-repository URL. The API:
+Curated creation submits the selected module ID instead of a notebooks repository URL. The API:
 
 1. Loads the validated catalog entry.
 2. Verifies that its engine matches the experiment engine.
@@ -188,21 +140,11 @@ repository URL. The API:
 8. Removes temporary Git data.
 9. Continues the existing PDB, uploaded-file, or repository-record import.
 
-The default Git host is expected to support partial clone, allowing unselected
-file blobs to remain undownloaded. If the host ignores or does not support blob
-filtering, creation may download additional Git objects, but MDDash still copies
-only the selected module into the experiment.
+The default Git host is expected to support partial clone, allowing unselected file blobs to remain undownloaded. If the host ignores or does not support blob filtering, creation may download additional Git objects, but MDDash still copies only the selected module into the experiment.
 
-Custom creation keeps the existing API and clone semantics: shallow-clone the
-remote default branch, remove `.git`, and copy the complete repository root into
-the experiment. No directory convention, catalog, or sparse checkout is applied
-to custom repositories.
+Custom creation keeps the existing API and clone semantics: shallow-clone the remote default branch, remove `.git`, and copy the complete repository root into the experiment. No directory convention, catalog, or sparse checkout is applied to custom repositories.
 
-The initial implementation does not add database columns. The existing
-`notebooks_repo` value stores the configured default repository for curated
-experiments and the submitted URL for custom experiments. The selected module
-is creation input used to construct the workspace; the copied workspace remains
-the experiment's executable notebook source.
+The initial implementation does not add database columns. The existing `notebooks_repo` value stores the configured default repository for curated experiments and the submitted URL for custom experiments. The selected module is creation input used to construct the workspace; the copied workspace remains the experiment's executable notebook source.
 
 ## Errors And Cleanup
 
@@ -214,52 +156,37 @@ Curated creation reports distinct errors for:
 - selected module path missing from the repository; and
 - failure while copying module content.
 
-Errors must not include authenticated URLs or tokens. Existing experiment
-directory cleanup remains in effect when preparation fails.
+Errors must not include authenticated URLs or tokens. Existing experiment directory cleanup remains in effect when preparation fails.
 
-Custom repository validation, authentication, timeout, and cleanup behavior
-remain unchanged by this feature.
+Custom repository validation, authentication, timeout, and cleanup behavior remain unchanged by this feature.
 
 ## Rollout
 
-The catalog and notebooks repository live in separate repositories and no Git
-ref is pinned. Use an overlap rollout to prevent either application version from
-observing an incompatible layout:
+The catalog and notebooks repository live in separate repositories and no Git ref is pinned. Use an overlap rollout to prevent either application version from observing an incompatible layout:
 
-1. Add `gromacs/protein/` and `amber/protein/` to `mddash-notebooks` while
-   temporarily retaining the current root-level files.
-2. Deploy the MDDash release that provides module selection and selective
-   checkout.
-3. After supported MDDash deployments use the new flow, remove the duplicate
-   root-level notebook files from `mddash-notebooks`.
+1. Add `gromacs/protein/` and `amber/protein/` to `mddash-notebooks` while temporarily retaining the current root-level files.
+2. Deploy the MDDash release that provides module selection and selective checkout.
+3. After supported MDDash deployments use the new flow, remove the duplicate root-level notebook files from `mddash-notebooks`.
 
-An older MDDash version continues to find root notebooks during step 2. The new
-version finds the module directories from step 1. This avoids requiring branch
-or tag configuration solely for migration coordination.
+An older MDDash version continues to find root notebooks during step 2. The new version finds the module directories from step 1. This avoids requiring branch or tag configuration solely for migration coordination.
 
 ## Testing
 
 ### Catalog
 
 - Validate the bundled catalog against its JSON Schema.
-- Reject duplicate IDs, unsupported engines, unknown schema versions, and
-  unsafe paths.
-- Verify the catalog endpoint returns stable display metadata without internal
-  paths or repository credentials.
+- Reject duplicate IDs, unsupported engines, unknown schema versions, and unsafe paths.
+- Verify the catalog endpoint returns stable display metadata without internal paths or repository credentials.
 
 ### API And Git
 
-- Create each curated protein module and verify that only its files appear in
-  the experiment root.
+- Create each curated protein module and verify that only its files appear in the experiment root.
 - Reject unknown and engine-incompatible module IDs.
 - Report a missing configured module path and remove the partial experiment.
-- Verify shallow partial-clone arguments and the fallback behavior of a server
-  without blob filtering.
-- Verify custom repositories still copy their complete root, including root
-  Binder files.
+- Verify shallow partial-clone arguments and the fallback behavior of a server without blob filtering.
+- Verify custom repositories still copy their complete root, including root Binder files.
 - Verify private custom repository tokens remain transient and redacted.
-- Exercise PDB, uploaded-file, and repository-record initialization with a
-  curated module.
+- Exercise PDB, uploaded-file, and repository-record initialization with a curated module.
 
 ### UI
 
@@ -267,25 +194,18 @@ or tag configuration solely for migration coordination.
 - Filter module cards when the engine changes and clear incompatible choices.
 - Require a module selection before curated creation.
 - Submit module ID and engine without trusting a client-provided path.
-- Switch between curated and custom modes and clear custom credentials when
-  leaving custom mode.
+- Switch between curated and custom modes and clear custom credentials when leaving custom mode.
 - Preserve existing custom URL validation, token controls, and pending state.
 - Display catalog-load and creation errors with retry behavior.
 
 ### Repository Migration
 
-- Verify each reorganized module contains every notebook, helper, and schema it
-  needs when copied alone into an empty experiment directory.
-- Smoke-test GROMACS and AMBER protein setup from `input.pdb` after selective
-  checkout.
+- Verify each reorganized module contains every notebook, helper, and schema it needs when copied alone into an empty experiment directory.
+- Smoke-test GROMACS and AMBER protein setup from `input.pdb` after selective checkout.
 
 ## Future Extensions
 
-- Add membrane, ligand, nucleic-acid, and other curated modules by extending the
-  bundled catalog and default repository together.
-- Add dedicated Binder repository discovery or presentation if custom Binder
-  usage requires more guidance than the existing Git flow.
-- Add configurable catalogs if installations demonstrate a need for their own
-  curated product modules.
-- Record resolved Git commits or support explicit refs if notebook provenance
-  and reproducible re-import become requirements.
+- Add membrane, ligand, nucleic-acid, and other curated modules by extending the bundled catalog and default repository together.
+- Add dedicated Binder repository discovery or presentation if custom Binder usage requires more guidance than the existing Git flow.
+- Add configurable catalogs if installations demonstrate a need for their own curated product modules.
+- Record resolved Git commits or support explicit refs if notebook provenance and reproducible re-import become requirements.

--- a/docs/superpowers/specs/2026-07-23-curated-notebook-modules-design.md
+++ b/docs/superpowers/specs/2026-07-23-curated-notebook-modules-design.md
@@ -1,0 +1,291 @@
+# Curated Notebook Modules Design
+
+## Summary
+
+MDDash will present curated notebook modules from the configured default
+notebooks repository. Users choose an MD engine and then choose a compatible
+module, such as the GROMACS protein workflow. MDDash checks out only that
+module's directory and copies its contents into the experiment root.
+
+The repository URL is not displayed in the normal creation flow. Users can
+choose a secondary custom-repository flow when they need their own Git or
+Binder-compatible repository. Custom repositories retain the current behavior:
+MDDash clones the complete default branch and copies the repository root into
+the experiment.
+
+## Goals
+
+- Show curated notebook workflows as product modules rather than Git paths.
+- Filter modules by the experiment's selected MD engine.
+- Copy only the selected curated module into a new experiment.
+- Keep each curated module self-contained in the notebooks repository.
+- Preserve full support for arbitrary custom repositories.
+- Keep the default creation flow free of repository configuration fields.
+- Leave room for additional protein, membrane, ligand, and other workflows.
+
+## Non-Goals
+
+- Discovering modules from arbitrary repositories.
+- Requiring custom repositories to follow the curated directory layout.
+- Selective checkout of custom repositories.
+- User-selectable Git branches, tags, or commits.
+- A dedicated Binder catalog or Binder-specific creation flow.
+- Runtime operator overrides of the curated module catalog.
+- Updating notebook content after experiment creation.
+
+Custom repositories may continue to contain Binder configuration. The existing
+notebook startup behavior remains responsible for using it.
+
+## Current State
+
+Experiment creation currently accepts an always-visible notebooks repository
+URL. The API shallow-clones the remote default branch, removes `.git`, and moves
+all repository-root content into the experiment directory. The selected engine
+does not affect the clone.
+
+The current `mddash-notebooks` default branch contains seven root-level files:
+
+```text
+amber-protein-setup.ipynb
+amber.schema.json
+amber_wrapper.py
+gromacs.schema.json
+mdanalysis_utils.py
+protein-analysis.ipynb
+protein-setup.ipynb
+```
+
+The files form two self-contained groups:
+
+- GROMACS protein: `protein-setup.ipynb`, `protein-analysis.ipynb`,
+  `mdanalysis_utils.py`, and `gromacs.schema.json`.
+- AMBER protein: `amber-protein-setup.ipynb`, `amber_wrapper.py`, and
+  `amber.schema.json`.
+
+The repository has no Binder configuration. Both setup notebooks expect
+`input.pdb` and write their simulation manifest and generated directories
+relative to the experiment root.
+
+## Curated Repository Layout
+
+The initial repository organization is:
+
+```text
+gromacs/
+  protein/
+    protein-setup.ipynb
+    protein-analysis.ipynb
+    mdanalysis_utils.py
+    gromacs.schema.json
+
+amber/
+  protein/
+    amber-protein-setup.ipynb
+    amber_wrapper.py
+    amber.schema.json
+```
+
+Future modules use the same engine/module shape, for example
+`gromacs/membrane/` or `amber/protein-ligand/`. The shape is a first-party
+organization convention, not a discovery contract for custom repositories.
+
+Each module must be self-contained. Notebooks, local Python helpers, schemas,
+and optional environment or Binder files required by that workflow live inside
+the module directory. MDDash copies the directory's contents, not the directory
+itself, into the experiment root. This preserves the current assumptions about
+`input.pdb`, local imports, schema paths, and generated simulation files.
+
+## Module Catalog
+
+MDDash owns a versioned `notebook-modules.json` file bundled with the Dashboard
+API image. It is product content and is not part of runtime deployment
+configuration. The existing `defaultNotebooksRepo` setting remains the only
+operator-configurable part of the curated source.
+
+The initial catalog is equivalent to:
+
+```json
+{
+  "schema_version": 1,
+  "modules": [
+    {
+      "id": "gromacs-protein",
+      "name": "Protein",
+      "description": "Prepare and analyze a solvated protein with GROMACS.",
+      "engine": "GMX",
+      "path": "gromacs/protein"
+    },
+    {
+      "id": "amber-protein",
+      "name": "Protein",
+      "description": "Prepare a solvated protein with AMBER.",
+      "engine": "AMBER",
+      "path": "amber/protein"
+    }
+  ]
+}
+```
+
+A JSON Schema stored in the MDDash repository validates the JSON catalog in CI
+and when the API starts. Validation requires a supported schema version, unique
+module IDs, non-empty display fields, a known engine, and a safe relative path.
+Paths may not be absolute or contain `..`, empty components, backslashes, or
+control characters. Invalid bundled product configuration is a startup error,
+not a recoverable user error.
+
+The API is the catalog's single source of truth. A read-only endpoint returns
+the display metadata required by the UI. It need not return repository URLs or
+paths. Experiment creation accepts a module ID, and the API resolves that ID to
+the server-side engine and path. It rejects a module whose engine differs from
+the submitted experiment engine.
+
+Changing `defaultNotebooksRepo` is supported, but the replacement repository
+must implement the paths in the bundled catalog. Installations needing a
+different curated catalog can introduce a runtime override in a future design;
+arbitrary user repositories use the custom flow instead.
+
+## Creation UX
+
+The normal creation form has this order:
+
+1. Experiment name.
+2. MD engine selection.
+3. Initial data selection and fields.
+4. Notebook module selection.
+5. Create experiment.
+
+The module section fetches the bundled catalog through the API and shows only
+modules compatible with the selected engine. Modules are presented by name and
+description; internal Git paths are not shown. A module selection is required,
+including when only one compatible module currently exists. Changing engines
+clears an incompatible selection and displays the new engine's modules.
+
+The repository input is absent from this default view. A secondary **Use custom
+notebooks repository** action switches the module section into custom mode and
+reveals the current repository URL and optional access-token controls. Custom
+mode retains the explicit engine selected above. It does not show module or
+subdirectory selection.
+
+Switching back to curated modules clears the custom URL and token from form
+state. Tokens remain transient and are never persisted.
+
+Loading the module catalog is independent of Git access and requires no
+repository probe. If catalog loading fails, creation is disabled and the UI
+offers a retry. Custom repository creation remains available.
+
+## API And Clone Behavior
+
+Curated creation submits the selected module ID instead of a notebooks
+repository URL. The API:
+
+1. Loads the validated catalog entry.
+2. Verifies that its engine matches the experiment engine.
+3. Uses the configured `defaultNotebooksRepo` and its remote default branch.
+4. Performs a shallow partial clone in a temporary directory.
+5. Sparse-checks out the catalog entry's path.
+6. Verifies that the path exists and is a directory in the checked-out commit.
+7. Copies that directory's contents into the experiment root.
+8. Removes temporary Git data.
+9. Continues the existing PDB, uploaded-file, or repository-record import.
+
+The default Git host is expected to support partial clone, allowing unselected
+file blobs to remain undownloaded. If the host ignores or does not support blob
+filtering, creation may download additional Git objects, but MDDash still copies
+only the selected module into the experiment.
+
+Custom creation keeps the existing API and clone semantics: shallow-clone the
+remote default branch, remove `.git`, and copy the complete repository root into
+the experiment. No directory convention, catalog, or sparse checkout is applied
+to custom repositories.
+
+The initial implementation does not add database columns. The existing
+`notebooks_repo` value stores the configured default repository for curated
+experiments and the submitted URL for custom experiments. The selected module
+is creation input used to construct the workspace; the copied workspace remains
+the experiment's executable notebook source.
+
+## Errors And Cleanup
+
+Curated creation reports distinct errors for:
+
+- unknown or engine-incompatible module ID;
+- unreachable configured repository;
+- clone timeout or Git failure;
+- selected module path missing from the repository; and
+- failure while copying module content.
+
+Errors must not include authenticated URLs or tokens. Existing experiment
+directory cleanup remains in effect when preparation fails.
+
+Custom repository validation, authentication, timeout, and cleanup behavior
+remain unchanged by this feature.
+
+## Rollout
+
+The catalog and notebooks repository live in separate repositories and no Git
+ref is pinned. Use an overlap rollout to prevent either application version from
+observing an incompatible layout:
+
+1. Add `gromacs/protein/` and `amber/protein/` to `mddash-notebooks` while
+   temporarily retaining the current root-level files.
+2. Deploy the MDDash release that provides module selection and selective
+   checkout.
+3. After supported MDDash deployments use the new flow, remove the duplicate
+   root-level notebook files from `mddash-notebooks`.
+
+An older MDDash version continues to find root notebooks during step 2. The new
+version finds the module directories from step 1. This avoids requiring branch
+or tag configuration solely for migration coordination.
+
+## Testing
+
+### Catalog
+
+- Validate the bundled catalog against its JSON Schema.
+- Reject duplicate IDs, unsupported engines, unknown schema versions, and
+  unsafe paths.
+- Verify the catalog endpoint returns stable display metadata without internal
+  paths or repository credentials.
+
+### API And Git
+
+- Create each curated protein module and verify that only its files appear in
+  the experiment root.
+- Reject unknown and engine-incompatible module IDs.
+- Report a missing configured module path and remove the partial experiment.
+- Verify shallow partial-clone arguments and the fallback behavior of a server
+  without blob filtering.
+- Verify custom repositories still copy their complete root, including root
+  Binder files.
+- Verify private custom repository tokens remain transient and redacted.
+- Exercise PDB, uploaded-file, and repository-record initialization with a
+  curated module.
+
+### UI
+
+- Hide the repository field in curated mode.
+- Filter module cards when the engine changes and clear incompatible choices.
+- Require a module selection before curated creation.
+- Submit module ID and engine without trusting a client-provided path.
+- Switch between curated and custom modes and clear custom credentials when
+  leaving custom mode.
+- Preserve existing custom URL validation, token controls, and pending state.
+- Display catalog-load and creation errors with retry behavior.
+
+### Repository Migration
+
+- Verify each reorganized module contains every notebook, helper, and schema it
+  needs when copied alone into an empty experiment directory.
+- Smoke-test GROMACS and AMBER protein setup from `input.pdb` after selective
+  checkout.
+
+## Future Extensions
+
+- Add membrane, ligand, nucleic-acid, and other curated modules by extending the
+  bundled catalog and default repository together.
+- Add dedicated Binder repository discovery or presentation if custom Binder
+  usage requires more guidance than the existing Git flow.
+- Add configurable catalogs if installations demonstrate a need for their own
+  curated product modules.
+- Record resolved Git commits or support explicit refs if notebook provenance
+  and reproducible re-import become requirements.


### PR DESCRIPTION
## Summary

Replaces the always-visible notebooks repository URL field with curated module cards filtered by engine. Users select a workflow (e.g. GROMACS Protein) instead of pasting a Git URL. The backend selectively checks out only the chosen module's directory via sparse checkout, rather than cloning the entire repo.

Custom repositories remain fully supported via a secondary toggle.

## Changes

### Backend
- **Bundled catalog** ( + ): versioned JSON catalog of curated modules, validated against JSON Schema at API startup
- **Catalog module** (): loading, validation, lookup by ID/engine, public display metadata; supports optional  field for external repos and  for root-clone (Binder) modules
- **Selective checkout** ():  — shallow partial clone () + sparse checkout of the module directory, with fallback to normal shallow clone
- **Experiment factory** ():  accepts ; resolves module from catalog, verifies engine match, uses sparse or full clone accordingly
- **Route** (): POST handler resolves ; curated mode sends module ID, custom mode sends repo URL as before
- **Endpoint** ():  returns display metadata without internal paths

### Frontend
- : rewritten — engine selection first, curated module cards filtered by engine (required selection), "Use custom notebooks repository" toggle with ghost button styling, "Back to curated workflows" clears custom credentials
- : TanStack Query hook for catalog fetching
- :  interface

### Tests (37 new)
- Catalog: schema validation, duplicate IDs, unsafe paths, engine filtering, repository field, root path, public metadata exclusion
- Sparse checkout: selective file copy, missing path, clone failure/timeout, partial-clone args, fallback, token redaction
- Factory: curated selective checkout, engine mismatch, unknown module, cleanup on failure, root-path full clone, custom full-clone preservation
- Route: curated creation, engine mismatch, unknown module, repository URL storage, custom mode

## Verification
- `make fix` — ruff + prettier + eslint clean
- `make type-check` — ty + tsgo + tsc clean
- `make test` — 502 tests pass (334 API + 25 auth + 91 mdrun-api + 61 helm)