### PR TITLE
fix(api): bundle manifest schemas, reference by URL

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM hairyhenderson/gomplate:v5.2.0 AS gomplate
-FROM rhysd/actionlint:v1.7.12 AS actionlint
+FROM rhysd/actionlint:1.7.12 AS actionlint
 FROM mikefarah/yq:4.53.3 AS yq
 
 FROM mcr.microsoft.com/devcontainers/base:ubuntu26.04

--- a/dashboard/api/AGENTS.md
+++ b/dashboard/api/AGENTS.md
@@ -15,7 +15,7 @@ Flask REST API that orchestrates molecular dynamics experiments across Kubernete
 ### Simulation Manifests (`.simulation.json`)
 - **Single source of truth**: each manifest declares file roles (`topology`, `structure`, `trajectory` for GMX; `topology`, `coordinates`, `control`, `trajectory` for AMBER) and `extra_args`. Job models reference `simulation_path` — they no longer store file names.
 - `list_simulation_files()` finds `*.simulation.json` anywhere under the experiment directory (not just `production/`).
-- `get_simulation()` validates against the JSON Schema referenced by `$schema`; invalid simulations are returned with errors and can't be used by downstream steps.
+- `get_simulation()` validates against the JSON Schema referenced by `$schema` (which must be a mddash schema URL — see `manifest_schema.py`); invalid simulations are returned with errors and can't be used by downstream steps.
 - A simulation is locked when its file is read-only or when a tuner/production job references its `simulation_path`. `mark_simulation_readonly()` chmods the file `0444`.
 
 ### Migrations

--- a/dashboard/api/_demo/files.py
+++ b/dashboard/api/_demo/files.py
@@ -1,12 +1,13 @@
 import io
 import json
-import os
 import shutil
 import zipfile
 from functools import lru_cache
 from pathlib import Path
 
 from config import DATA_DIR
+from enums import Engine
+from manifest_schema import schema_url
 
 DEMO_DATA_DIR = Path(__file__).resolve().parent / "data"
 DEFAULT_TPR_FILE = DEMO_DATA_DIR / "md.tpr"
@@ -26,73 +27,6 @@ MDPOSIT_DEMO_FILES = {
     "mdposit/trajectory.xtc": DEFAULT_XTC_FILE,
 }
 
-GMX_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "MDDash GROMACS simulation manifest",
-    "type": "object",
-    "required": ["name", "engine", "files", "extra_args"],
-    "additionalProperties": False,
-    "properties": {
-        "$schema": {"type": "string"},
-        "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$"},
-        "engine": {"const": "GMX"},
-        "files": {
-            "type": "object",
-            "required": ["run_input", "reference_structure", "trajectory"],
-            "additionalProperties": False,
-            "properties": {
-                "run_input": {"type": "string"},
-                "run_structure": {"type": "string"},
-                "reference_structure": {"type": "string"},
-                "trajectory": {"type": "string"},
-            },
-        },
-        "extra_args": {"type": "string"},
-    },
-}
-
-AMBER_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "MDDash AMBER simulation manifest",
-    "type": "object",
-    "required": ["name", "engine", "files", "extra_args"],
-    "additionalProperties": False,
-    "properties": {
-        "$schema": {"type": "string"},
-        "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$"},
-        "engine": {"const": "AMBER"},
-        "files": {
-            "type": "object",
-            "required": ["topology", "coordinates", "control", "reference_structure", "trajectory"],
-            "additionalProperties": False,
-            "properties": {
-                "topology": {"type": "string"},
-                "coordinates": {"type": "string"},
-                "control": {"type": "string"},
-                "reference_structure": {"type": "string"},
-                "trajectory": {"type": "string"},
-            },
-        },
-        "extra_args": {"type": "string"},
-    },
-}
-
-
-def ensure_schema_files(experiment_id: str) -> None:
-    experiment_dir = DATA_DIR / experiment_id
-    experiment_dir.mkdir(parents=True, exist_ok=True)
-    _write_json_if_missing(experiment_dir / "gromacs.schema.json", GMX_SCHEMA)
-    _write_json_if_missing(experiment_dir / "amber.schema.json", AMBER_SCHEMA)
-
-
-def _write_json_if_missing(path: Path, data: dict) -> None:
-    if not path.exists():
-        path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-
-
-def _schema_ref(schema_path: Path, sim_dir: Path) -> str:
-    return os.path.relpath(schema_path, start=sim_dir)
-
 
 def write_gmx_simulation(
     experiment_id: str,
@@ -107,9 +41,8 @@ def write_gmx_simulation(
     sim_path = simulation_path or f"{name}.simulation.json"
     sim_file = experiment_dir / sim_path
     sim_file.parent.mkdir(parents=True, exist_ok=True)
-    sim_dir = sim_file.parent
     content = {
-        "$schema": _schema_ref(experiment_dir / "gromacs.schema.json", sim_dir),
+        "$schema": schema_url(Engine.GMX),
         "name": name,
         "engine": "GMX",
         "files": {
@@ -137,9 +70,8 @@ def write_amber_simulation(
     sim_path = simulation_path or f"{name}.simulation.json"
     sim_file = experiment_dir / sim_path
     sim_file.parent.mkdir(parents=True, exist_ok=True)
-    sim_dir = sim_file.parent
     content = {
-        "$schema": _schema_ref(experiment_dir / "amber.schema.json", sim_dir),
+        "$schema": schema_url(Engine.AMBER),
         "name": name,
         "engine": "AMBER",
         "files": {

--- a/dashboard/api/_demo/profile.py
+++ b/dashboard/api/_demo/profile.py
@@ -14,7 +14,6 @@ import responses
 from flask import redirect, request, session
 from token_manager import MDREPO_TOKEN_EXPIRES_AT, MDREPO_TOKEN_KEY
 
-from .files import ensure_schema_files
 from .mocks import install_all_mocks
 from .seed import seed_data
 from .state import demo_state
@@ -53,7 +52,6 @@ def setup_demo_profile(app: "Flask") -> None:
 
     # Install demo MDRepo auth bypass
     _install_demo_mdrepo_auth(app)
-    _install_demo_schema_guard(app)
 
     # Configure session for local development
     app.config["SESSION_COOKIE_SECURE"] = False
@@ -107,18 +105,6 @@ def _install_demo_mdrepo_auth(app: "Flask") -> None:
         return redirect(_with_query_param(return_url, "mdrepo_auth", "success"))
 
     app.view_functions[endpoint] = _demo_mdrepo_auth
-
-
-def _install_demo_schema_guard(app: "Flask") -> None:
-    """Ensure demo schema files exist before writing simulation manifests."""
-
-    @app.before_request
-    def _ensure_demo_schema_files() -> None:
-        if request.endpoint not in {"simulations.create_simulation_route", "simulations.update_simulation_route"}:
-            return
-        experiment_id = (request.view_args or {}).get("experiment_id")
-        if isinstance(experiment_id, str):
-            ensure_schema_files(experiment_id)
 
 
 def _with_query_param(url: str, key: str, value: str) -> str:

--- a/dashboard/api/_demo/seed.py
+++ b/dashboard/api/_demo/seed.py
@@ -15,7 +15,6 @@ from .files import (
     ensure_amber_demo_files,
     ensure_demo_files,
     ensure_mdposit_demo_files,
-    ensure_schema_files,
     write_amber_simulation,
     write_finished_gmx_log,
     write_gmx_simulation,
@@ -464,11 +463,9 @@ def seed_data() -> None:  # ruff:ignore[too-many-locals]
     # MDPosit import study: mirrors the project file layout exposed by HTTP mocks.
     ensure_mdposit_demo_files(mdposit_demo.id)
 
-    # Seed schema files and simulation manifests for each experiment
-    ensure_schema_files(membrane.id)
+    # Seed simulation manifests for each experiment
     write_gmx_simulation(membrane.id, "gpcr_membrane", topology="gpcr_membrane.tpr")
 
-    ensure_schema_files(enzyme.id)
     write_gmx_simulation(enzyme.id, "md", simulation_path="md.simulation.json", topology="production/md.tpr")
     write_gmx_simulation(enzyme.id, "npt_equilibration", simulation_path="npt_equilibration.simulation.json")
     write_gmx_simulation(
@@ -478,7 +475,6 @@ def seed_data() -> None:  # ruff:ignore[too-many-locals]
         topology="hiv_protease_apo_enzyme_wild_type_production_run_2024.tpr",
     )
 
-    ensure_schema_files(published.id)
     write_gmx_simulation(
         published.id,
         "lysozyme_hewl",
@@ -486,7 +482,6 @@ def seed_data() -> None:  # ruff:ignore[too-many-locals]
         topology="lysozyme_hewl.tpr",
     )
 
-    ensure_schema_files(amber_folding.id)
     write_amber_simulation(
         amber_folding.id,
         "villin",
@@ -504,7 +499,6 @@ def seed_data() -> None:  # ruff:ignore[too-many-locals]
         control="equilibration.mdin",
     )
 
-    ensure_schema_files(amber_dna.id)
     write_amber_simulation(
         amber_dna.id,
         "dna",
@@ -640,13 +634,11 @@ def _rehydrate_runtime_state() -> None:  # ruff:ignore[too-many-branches]
         demo_state.notebook_status[mdposit_demo.id] = PodStatus.DOWN
         ensure_mdposit_demo_files(mdposit_demo.id)
 
-    # Re-seed schema files and simulation manifests for rehydrated experiments
+    # Re-seed simulation manifests for rehydrated experiments
     if membrane is not None:
-        ensure_schema_files(membrane.id)
         write_gmx_simulation(membrane.id, "gpcr_membrane", topology="gpcr_membrane.tpr")
 
     if enzyme is not None:
-        ensure_schema_files(enzyme.id)
         write_gmx_simulation(enzyme.id, "md", simulation_path="md.simulation.json", topology="production/md.tpr")
         write_gmx_simulation(enzyme.id, "npt_equilibration", simulation_path="npt_equilibration.simulation.json")
         write_gmx_simulation(
@@ -657,7 +649,6 @@ def _rehydrate_runtime_state() -> None:  # ruff:ignore[too-many-branches]
         )
 
     if published is not None:
-        ensure_schema_files(published.id)
         write_gmx_simulation(
             published.id,
             "lysozyme_hewl",
@@ -666,7 +657,6 @@ def _rehydrate_runtime_state() -> None:  # ruff:ignore[too-many-branches]
         )
 
     if amber_folding is not None:
-        ensure_schema_files(amber_folding.id)
         write_amber_simulation(
             amber_folding.id,
             "villin",
@@ -685,7 +675,6 @@ def _rehydrate_runtime_state() -> None:  # ruff:ignore[too-many-branches]
         )
 
     if amber_dna is not None:
-        ensure_schema_files(amber_dna.id)
         write_amber_simulation(
             amber_dna.id,
             "dna",

--- a/dashboard/api/manifest_schema.py
+++ b/dashboard/api/manifest_schema.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import re
+from functools import lru_cache
+from pathlib import Path
+
+from enums import Engine
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_DIR = Path(__file__).resolve().parent / "manifest_schemas"
+_ENGINE_FILE = {Engine.GMX: "gromacs.schema.json", Engine.AMBER: "amber.schema.json"}
+_SCHEMA_URL_RE = re.compile(
+    r"^https://raw\.githubusercontent\.com/CERIT-SC/mddash/.+/dashboard/api/manifest_schemas/(gromacs|amber)\.schema\.json$"
+)
+
+
+def schema_url(engine: Engine) -> str:
+    """Build the schema URL the API writes into manifests."""
+    return f"https://raw.githubusercontent.com/CERIT-SC/mddash/v0.1.4/dashboard/api/manifest_schemas/{_ENGINE_FILE[engine]}"
+
+
+@lru_cache(maxsize=2)
+def _bundled(filename: str) -> dict | None:
+    try:
+        return json.loads((_SCHEMA_DIR / filename).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.error("Failed to load bundled schema: %s", filename)
+        return None
+
+
+def resolve_schema_url(ref: object) -> dict | None:
+    """Resolve a $schema URL to the bundled schema (any ref); None if unrecognized."""
+    if not isinstance(ref, str):
+        return None
+    match = _SCHEMA_URL_RE.match(ref)
+    return _bundled(f"{match.group(1)}.schema.json") if match else None

--- a/dashboard/api/manifest_schemas/amber.schema.json
+++ b/dashboard/api/manifest_schemas/amber.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MDDash AMBER simulation manifest",
+  "type": "object",
+  "required": ["name", "engine", "files", "extra_args"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
+    "engine": { "const": "AMBER" },
+    "files": {
+      "type": "object",
+      "required": ["topology", "coordinates", "control", "reference_structure", "trajectory"],
+      "additionalProperties": false,
+      "properties": {
+        "topology": { "$ref": "#/$defs/relpath" },
+        "coordinates": { "$ref": "#/$defs/relpath" },
+        "control": { "$ref": "#/$defs/relpath" },
+        "reference_structure": { "$ref": "#/$defs/relpath" },
+        "trajectory": { "$ref": "#/$defs/relpath" }
+      }
+    },
+    "extra_args": { "type": "string" }
+  },
+  "$defs": {
+    "relpath": {
+      "type": "string",
+      "description": "Path relative to the experiment directory.",
+      "pattern": "^[A-Za-z0-9_./-]+$",
+      "not": { "pattern": "^/|\\.\\.|//" }
+    }
+  }
+}

--- a/dashboard/api/manifest_schemas/gromacs.schema.json
+++ b/dashboard/api/manifest_schemas/gromacs.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MDDash GROMACS simulation manifest",
+  "type": "object",
+  "required": ["name", "engine", "files", "extra_args"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
+    "engine": { "const": "GMX" },
+    "files": {
+      "type": "object",
+      "required": ["run_input", "reference_structure", "trajectory"],
+      "additionalProperties": false,
+      "properties": {
+        "run_input": { "$ref": "#/$defs/relpath" },
+        "run_structure": { "$ref": "#/$defs/relpath" },
+        "reference_structure": { "$ref": "#/$defs/relpath" },
+        "trajectory": { "$ref": "#/$defs/relpath" }
+      }
+    },
+    "extra_args": { "type": "string" }
+  },
+  "$defs": {
+    "relpath": {
+      "type": "string",
+      "description": "Path relative to the experiment directory.",
+      "pattern": "^[A-Za-z0-9_./-]+$",
+      "not": { "pattern": "^/|\\.\\.|//" }
+    }
+  }
+}

--- a/dashboard/api/models/experiment.py
+++ b/dashboard/api/models/experiment.py
@@ -46,7 +46,6 @@ from werkzeug.exceptions import BadRequest, Conflict, InternalServerError, NotFo
 from werkzeug.utils import secure_filename
 
 from .experiment_sources import (
-    chmod_schema_files_readonly,
     fetch_pdb,
     import_invenio_repo,
     import_mdposit_repo,
@@ -178,7 +177,6 @@ class Experiment(db.Model):  # type: ignore
             rmtree(experiment_dir, ignore_errors=True)
             raise
 
-        chmod_schema_files_readonly(experiment_dir)
         return experiment_id
 
     @classmethod

--- a/dashboard/api/models/experiment_sources.py
+++ b/dashboard/api/models/experiment_sources.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 _REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 _PDB_STRUCTURE_RECORDS = {"ATOM", "HETATM"}
-_SCHEMA_FILES = ("gromacs.schema.json", "amber.schema.json")
 
 
 def list_simulations(experiment_id: str) -> list["Simulation"]:
@@ -86,17 +85,6 @@ def validate_pdb_content(content: bytes) -> None:
         if line[:6].strip() in _PDB_STRUCTURE_RECORDS:
             return
     raise BadRequest(description="Downloaded content is not a valid PDB file (no ATOM or HETATM records).")
-
-
-def chmod_schema_files_readonly(experiment_dir: Path) -> None:
-    """Best-effort — failures are logged, not raised."""
-    for name in _SCHEMA_FILES:
-        schema_path = experiment_dir / name
-        if schema_path.is_file():
-            try:
-                Path(schema_path).chmod(0o444)
-            except OSError:
-                logger.warning("Failed to chmod schema file '%s' read-only", name, exc_info=True)
 
 
 def resolve_repo_link(repo_link: str) -> str:

--- a/dashboard/api/models/simulation.py
+++ b/dashboard/api/models/simulation.py
@@ -1,13 +1,13 @@
 import json
 import logging
 import os
-from functools import lru_cache
 from pathlib import Path
 
 import jsonschema
 from config import DATA_DIR
 from enums import Engine
 from extensions import db
+from manifest_schema import resolve_schema_url, schema_url
 from utils import FileInfo, get_files_with_extensions
 from validators import check_path
 from werkzeug.exceptions import BadRequest, NotFound
@@ -17,22 +17,8 @@ from .experiment import Experiment
 logger = logging.getLogger(__name__)
 
 SIMULATION_SUFFIX = ".simulation.json"
-ENGINE_SCHEMA_FILE: dict[Engine, str] = {
-    Engine.GMX: "gromacs.schema.json",
-    Engine.AMBER: "amber.schema.json",
-}
 READONLY_MODE = 0o444
 WRITABLE_MODE = 0o644
-
-
-@lru_cache(maxsize=16)
-def _load_schema(schema_path: Path) -> dict | None:
-    try:
-        if not schema_path.is_file():
-            return None
-        return json.loads(schema_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
 
 
 def _safe_default_path(name: str) -> str:
@@ -40,18 +26,13 @@ def _safe_default_path(name: str) -> str:
     return f"{safe_name}{SIMULATION_SUFFIX}"
 
 
-def _build_content(experiment_id: str, simulation_path: str, engine: Engine, payload: dict) -> dict:
-    schema_filename = ENGINE_SCHEMA_FILE[engine]
-    exp_dir = DATA_DIR / experiment_id
-    sim_dir = (exp_dir / simulation_path).parent
-    schema_ref = os.path.relpath(exp_dir / schema_filename, start=sim_dir)
-
+def _build_content(engine: Engine, payload: dict) -> dict:
     files = payload.get("files")
     if not isinstance(files, dict):
         raise BadRequest(description="'files' must be an object.")
 
     return {
-        "$schema": schema_ref,
+        "$schema": schema_url(engine),
         "name": payload.get("name", ""),
         "engine": engine.value,
         "files": files,
@@ -59,20 +40,10 @@ def _build_content(experiment_id: str, simulation_path: str, engine: Engine, pay
     }
 
 
-def _validate_content_or_raise(experiment_id: str, simulation_path: str, content: dict, engine: Engine) -> None:
-    exp_dir = DATA_DIR / experiment_id
-    simulation_file = exp_dir / simulation_path
-    schema_ref = content.get("$schema")
-    if not isinstance(schema_ref, str) or not schema_ref:
-        raise BadRequest(description="Missing or invalid '$schema' reference.")
-    schema_path = (simulation_file.parent / schema_ref).resolve()
-    try:
-        schema_path.relative_to(exp_dir.resolve())
-    except ValueError:
-        raise BadRequest(description=f"Schema file escapes experiment directory: {schema_ref}")
-    schema = _load_schema(schema_path)
+def _validate_content_or_raise(content: dict, engine: Engine) -> None:
+    schema = resolve_schema_url(content.get("$schema"))
     if schema is None:
-        raise BadRequest(description=f"Schema file is missing or unreadable: {schema_ref}")
+        raise BadRequest(description="Missing or invalid '$schema' reference; expected a mddash schema URL.")
     try:
         jsonschema.validate(content, schema)
     except jsonschema.ValidationError as exc:
@@ -260,14 +231,10 @@ class Simulation:  # ruff:ignore[too-many-public-methods]
         resolved = self.resolved_files
         exp_dir = DATA_DIR / self.experiment_id
 
-        schema_path = self._resolve_schema_path(exp_dir)
-        schema = _load_schema(schema_path) if schema_path is not None else None
-        if schema_path is None:
-            errors.append("Missing or invalid '$schema' reference.")
-        elif schema is None:
-            errors.append(f"Schema file missing or unreadable: {self._raw.get('$schema')}")
-
-        if schema is not None:
+        schema = resolve_schema_url(self._raw.get("$schema"))
+        if schema is None:
+            errors.append("Missing or invalid '$schema' reference; expected a mddash schema URL.")
+        else:
             try:
                 jsonschema.validate(self._raw, schema)
             except jsonschema.ValidationError as exc:
@@ -287,17 +254,6 @@ class Simulation:  # ruff:ignore[too-many-public-methods]
 
         self._validation = not errors, errors, missing
         return self._validation
-
-    def _resolve_schema_path(self, exp_dir: Path) -> Path | None:
-        schema_ref = self._raw.get("$schema")
-        if not isinstance(schema_ref, str) or not schema_ref:
-            return None
-        resolved = (self._file.parent / schema_ref).resolve()
-        try:
-            resolved.relative_to(exp_dir.resolve())
-        except ValueError:
-            return None
-        return resolved
 
     @staticmethod
     def is_locked(experiment_id: str, simulation_path: str) -> bool:
@@ -399,8 +355,8 @@ class Simulation:  # ruff:ignore[too-many-public-methods]
         if simulation_file.exists():
             raise BadRequest(description=f"Simulation '{simulation_path}' already exists.")
 
-        content = _build_content(experiment_id, simulation_path, experiment.engine, payload)
-        _validate_content_or_raise(experiment_id, simulation_path, content, experiment.engine)
+        content = _build_content(experiment.engine, payload)
+        _validate_content_or_raise(content, experiment.engine)
 
         simulation_file.parent.mkdir(parents=True, exist_ok=True)
         simulation_file.write_text(json.dumps(content, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -469,8 +425,8 @@ class Simulation:  # ruff:ignore[too-many-public-methods]
         if cls.is_locked(experiment_id, simulation_path):
             raise BadRequest(description=f"Simulation '{simulation_path}' is locked.")
 
-        content = _build_content(experiment_id, simulation_path, experiment.engine, payload)
-        _validate_content_or_raise(experiment_id, simulation_path, content, experiment.engine)
+        content = _build_content(experiment.engine, payload)
+        _validate_content_or_raise(content, experiment.engine)
 
         if simulation_file.exists() and not os.access(simulation_file, os.W_OK):
             try:

--- a/dashboard/api/tests/unit/test_manifest_schema.py
+++ b/dashboard/api/tests/unit/test_manifest_schema.py
@@ -1,0 +1,68 @@
+"""Unit tests for the manifest schema URL resolver."""
+
+from enums import Engine
+from manifest_schema import resolve_schema_url, schema_url
+
+GMX_URL = "https://raw.githubusercontent.com/CERIT-SC/mddash/v0.1.4/dashboard/api/manifest_schemas/gromacs.schema.json"
+AMBER_URL = "https://raw.githubusercontent.com/CERIT-SC/mddash/v0.1.4/dashboard/api/manifest_schemas/amber.schema.json"
+
+
+class TestSchemaUrl:
+    """schema_url builds the master-ref mddash schema URL."""
+
+    def test_gmx_url(self) -> None:
+        """GMX URL points at the bundled gromacs schema on master."""
+        assert schema_url(Engine.GMX) == GMX_URL
+
+    def test_amber_url(self) -> None:
+        """AMBER URL points at the bundled amber schema on master."""
+        assert schema_url(Engine.AMBER) == AMBER_URL
+
+
+class TestResolveSchemaUrl:
+    """resolve_schema_url maps whitelisted mddash URLs to bundled schemas."""
+
+    def test_resolves_gmx_url_to_bundled_schema(self) -> None:
+        """A valid GMX URL resolves to the bundled GROMACS schema."""
+        schema = resolve_schema_url(GMX_URL)
+        assert schema is not None
+        assert schema["title"] == "MDDash GROMACS simulation manifest"
+
+    def test_resolves_amber_url_to_bundled_schema(self) -> None:
+        """A valid AMBER URL resolves to the bundled AMBER schema."""
+        schema = resolve_schema_url(AMBER_URL)
+        assert schema is not None
+        assert schema["title"] == "MDDash AMBER simulation manifest"
+
+    def test_accepts_any_ref_tag_or_branch(self) -> None:
+        """Any ref (tag, branch, or slash-bearing branch) is accepted."""
+        for ref in ("v0.1.0", "v9.9.9", "master", "main", "feature/x"):
+            url = (
+                "https://raw.githubusercontent.com/CERIT-SC/mddash/"
+                f"{ref}/dashboard/api/manifest_schemas/gromacs.schema.json"
+            )
+            assert resolve_schema_url(url) is not None, ref
+
+    def test_rejects_non_mddash_url(self) -> None:
+        """A URL pointing at a different repo is rejected."""
+        assert resolve_schema_url("https://raw.githubusercontent.com/evil/repo/main/gromacs.schema.json") is None
+
+    def test_rejects_relative_path(self) -> None:
+        """A relative file path is rejected."""
+        assert resolve_schema_url("./gromacs.schema.json") is None
+
+    def test_rejects_arbitrary_url(self) -> None:
+        """An arbitrary non-GitHub URL is rejected."""
+        assert resolve_schema_url("https://example.com/schema.json") is None
+
+    def test_rejects_non_string(self) -> None:
+        """Non-string inputs are rejected."""
+        assert resolve_schema_url(None) is None  # type: ignore[arg-type]
+        assert resolve_schema_url(123) is None  # type: ignore[arg-type]
+
+    def test_rejects_wrong_filename(self) -> None:
+        """A URL with an unrecognized schema filename is rejected."""
+        url = (
+            "https://raw.githubusercontent.com/CERIT-SC/mddash/v0.1.0/dashboard/api/manifest_schemas/other.schema.json"
+        )
+        assert resolve_schema_url(url) is None

--- a/dashboard/api/tests/unit/test_mdposit_publish.py
+++ b/dashboard/api/tests/unit/test_mdposit_publish.py
@@ -1,45 +1,23 @@
 """Unit tests for MDPosit-aware publish routing and from_repo logic."""
 
 import json
-import os
 from collections.abc import Generator
 from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from enums import Engine
 from extensions import db, ma
 from flask import Flask
 from flask.testing import FlaskClient
+from manifest_schema import schema_url
 from models import Experiment, Notebook
 from routes import experiments_bp, mdrepo_bp
 from upload.status import UploadStatus
 from werkzeug.exceptions import BadRequest, InternalServerError
 
-GMX_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "MDDash GROMACS simulation manifest",
-    "type": "object",
-    "required": ["name", "engine", "files", "extra_args"],
-    "additionalProperties": False,
-    "properties": {
-        "$schema": {"type": "string"},
-        "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$"},
-        "engine": {"const": "GMX"},
-        "files": {
-            "type": "object",
-            "required": ["run_input", "reference_structure", "trajectory"],
-            "additionalProperties": False,
-            "properties": {
-                "run_input": {"type": "string"},
-                "run_structure": {"type": "string"},
-                "reference_structure": {"type": "string"},
-                "trajectory": {"type": "string"},
-            },
-        },
-        "extra_args": {"type": "string"},
-    },
-}
+GMX_SCHEMA_URL = schema_url(Engine.GMX)
 
 
 @pytest.fixture
@@ -114,17 +92,15 @@ def _write_gmx_simulation(
     files: dict[str, str] | None = None,
 ) -> str:
     """
-    Write schema files and a GMX simulation manifest.
+    Write a GMX simulation manifest.
 
     Returns:
         The simulation_path.
     """
-    (exp_dir / "gromacs.schema.json").write_text(json.dumps(GMX_SCHEMA))
     sim_file = exp_dir / simulation_path
     sim_file.parent.mkdir(parents=True, exist_ok=True)
-    sim_dir = sim_file.parent
     content = {
-        "$schema": os.path.relpath(exp_dir / "gromacs.schema.json", sim_dir),
+        "$schema": GMX_SCHEMA_URL,
         "name": name,
         "engine": "GMX",
         "files": files or {"run_input": "topol.tpr", "reference_structure": "struct.pdb", "trajectory": "traj.xtc"},

--- a/dashboard/api/tests/unit/test_simulation.py
+++ b/dashboard/api/tests/unit/test_simulation.py
@@ -1,40 +1,18 @@
 """Unit tests for the Simulation class."""
 
 import json
-import os
 from pathlib import Path
 
 import pytest
+from enums import Engine
 from extensions import db
 from flask import Flask
+from manifest_schema import schema_url
 from models import Experiment, Notebook
 from models.simulation import Simulation
 from werkzeug.exceptions import BadRequest
 
-GMX_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "MDDash GROMACS simulation manifest",
-    "type": "object",
-    "required": ["name", "engine", "files", "extra_args"],
-    "additionalProperties": False,
-    "properties": {
-        "$schema": {"type": "string"},
-        "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$"},
-        "engine": {"const": "GMX"},
-        "files": {
-            "type": "object",
-            "required": ["run_input", "reference_structure", "trajectory"],
-            "additionalProperties": False,
-            "properties": {
-                "run_input": {"type": "string"},
-                "run_structure": {"type": "string"},
-                "reference_structure": {"type": "string"},
-                "trajectory": {"type": "string"},
-            },
-        },
-        "extra_args": {"type": "string"},
-    },
-}
+GMX_SCHEMA_URL = schema_url(Engine.GMX)
 
 
 def _seed_experiment(app: Flask, exp_id: str = "simts") -> str:
@@ -54,10 +32,6 @@ def _seed_experiment(app: Flask, exp_id: str = "simts") -> str:
         return exp_id
 
 
-def _write_schema(exp_dir: Path) -> None:
-    (exp_dir / "gromacs.schema.json").write_text(json.dumps(GMX_SCHEMA))
-
-
 def _write_sim_file(exp_dir: Path, simulation_path: str, files: dict, name: str = "protein") -> str:
     """
     Write a GMX simulation manifest.
@@ -67,9 +41,8 @@ def _write_sim_file(exp_dir: Path, simulation_path: str, files: dict, name: str 
     """
     sim_file = exp_dir / simulation_path
     sim_file.parent.mkdir(parents=True, exist_ok=True)
-    sim_dir = sim_file.parent
     content = {
-        "$schema": os.path.relpath(exp_dir / "gromacs.schema.json", sim_dir),
+        "$schema": GMX_SCHEMA_URL,
         "name": name,
         "engine": "GMX",
         "files": files,
@@ -87,7 +60,6 @@ class TestDiscovery:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         _write_sim_file(
             exp_dir,
             "protein.simulation.json",
@@ -118,7 +90,6 @@ class TestDiscovery:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         _write_sim_file(
             exp_dir,
             "z.simulation.json",
@@ -148,7 +119,7 @@ class TestValidation:
         sim_file = exp_dir / sim_path
         sim_file.parent.mkdir(parents=True, exist_ok=True)
         content = {
-            "$schema": "../gromacs.schema.json",
+            "$schema": "https://example.com/not-allowed.schema.json",
             "name": "protein",
             "engine": "GMX",
             "files": {
@@ -170,7 +141,6 @@ class TestValidation:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         _write_sim_file(
             exp_dir,
             "protein.simulation.json",
@@ -196,7 +166,6 @@ class TestValidation:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         _write_sim_file(
             exp_dir,
             "protein.simulation.json",
@@ -227,7 +196,6 @@ class TestLocking:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         sim_path = _write_sim_file(
             exp_dir,
             "protein.simulation.json",
@@ -245,7 +213,6 @@ class TestLocking:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
         sim_path = _write_sim_file(
             exp_dir,
             "protein.simulation.json",
@@ -265,7 +232,6 @@ class TestWriteSimulation:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
 
         with app.app_context():
             sim = Simulation.write(
@@ -289,7 +255,6 @@ class TestWriteSimulation:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
 
         with app.app_context():
             Simulation.write(
@@ -324,7 +289,6 @@ class TestWriteSimulation:
         exp_id = _seed_experiment(app)
         exp_dir = tmp_path / exp_id
         exp_dir.mkdir(parents=True, exist_ok=True)
-        _write_schema(exp_dir)
 
         with app.app_context(), pytest.raises(BadRequest):
             Simulation.write(


### PR DESCRIPTION
## Summary

Manifests' `$schema` becomes a `raw.githubusercontent.com` URL into this repo; the API resolves it to a **bundled** copy of the schema (`manifest_schemas/`) without HTTP-fetching, so validation is offline and always present regardless of which repository was cloned.

Fixes #121 — schemas were only present when the cloned repo happened to carry them (curated modules), so experiments created from BioBB Binder or custom git repos failed with "Schema file is missing or unreadable" when validating a simulation.

## Changes

- **Bundle schemas** (`dashboard/api/manifest_schemas/{gromacs,amber}.schema.json`) — the stricter `$defs/relpath` traversal-guard version, replacing the weaker inline demo copies. Single source of truth.
- **`manifest_schema.py`** — `schema_url(engine)` builds the URL; `resolve_schema_url($schema)` maps a whitelisted mddash URL to the bundled schema (no network fetch). Invalid `$schema` → simulation invalid.
- **`simulation.py`** — `_build_content` emits the URL; validation uses the resolver; dropped local-file resolution (`_load_schema`, `_resolve_schema_path`).
- **Removed local-schema seeding** — `chmod_schema_files_readonly`, `_SCHEMA_FILES`, `ensure_schema_files`, the demo schema guard, and inline `GMX_SCHEMA`/`AMBER_SCHEMA`.
- **Tests** — use URL `$schema`; new `test_manifest_schema.py` covers the resolver.

## Why bundled, not fetched

Validation runs on every experiment listing (a read path). A runtime GitHub fetch would couple the UI to GitHub availability/rate-limits and add an SSRF surface (user-controllable `$schema`). The bundled copy is the same schema shipped in the image, read locally; the URL records the authored-against version and is human-resolvable.

## Verification

\`\`\`
make fix             # clean
make type-check      # ty + tsc: All checks passed
make test            # 532 passed
make validate-charts # rendered clean
\`\`\`

## Companion change

A matching commit in `sb-ncbr/mddash-notebooks` updates the setup notebooks to emit the `v0.1.4`-pinned URL and deletes the local schema files. The `v0.1.4` tag resolves on the URL once this is merged and released.

Fixes #121