### PR TITLE
feat(tuner): trustworthy job statuses end-to-end — Ray ground truth in the API, finish-aware stop/delete in the UI

### DIFF
--- a/dashboard/api/models/tuner_job.py
+++ b/dashboard/api/models/tuner_job.py
@@ -111,6 +111,12 @@ class TunerJob(db.Model):  # type: ignore
             # Update both caches on success
             tuner_status_cache[cache_key] = status
             tuner_last_known_status[cache_key] = status
+
+            # A finished job never changes again: persist trials and free the tuner.
+            if status["status"] == JobStatus.FINISHED:
+                self.stop()
+                db.session.commit()
+
             return status
 
         except TimeoutError:

--- a/dashboard/api/tests/unit/test_tuner_job.py
+++ b/dashboard/api/tests/unit/test_tuner_job.py
@@ -163,6 +163,50 @@ class TestTunerJobNotFound:
         assert job.is_stopped is False
 
 
+class TestTunerJobFinished:
+    """A FINISHED job must be persisted dashboard-side and stop polling the tuner."""
+
+    def setup_method(self) -> None:
+        """Clear tuner caches before each test."""
+        tuner_status_cache.clear()
+        tuner_last_known_status.clear()
+
+    def teardown_method(self) -> None:
+        """Clear tuner caches after each test."""
+        tuner_status_cache.clear()
+        tuner_last_known_status.clear()
+
+    def test_finished_poll_stops_job_and_preserves_trials(self, app: Flask, db_session: Session) -> None:
+        """A FINISHED status flips the job stopped and keeps performance-bearing trials."""
+        experiment = _make_experiment(db_session)
+        job = _make_tuner_job(experiment)
+        db_session.add(job)
+        db_session.commit()
+
+        finished_status = {
+            "status": JobStatus.FINISHED,
+            "trials": [
+                {"id": "t1", "performance": EXPECTED_PERFORMANCE},
+                {"id": "t2", "performance": None},
+            ],
+        }
+        with (
+            patch(
+                "models.tuner_job.tuner.amber_poll_status", side_effect=[finished_status, AssertionError("re-polled")]
+            ),
+            patch("models.tuner_job.tuner.amber_delete_job") as mock_delete,
+        ):
+            status = job._status()
+            job._status()
+
+        assert status == finished_status
+        assert job.is_stopped is True
+        assert mock_delete.call_count == 1
+        preserved = job.trials
+        assert len(preserved) == 1
+        assert preserved[0]["performance"] == pytest.approx(EXPECTED_PERFORMANCE)
+
+
 class TestTunerJobErrorStatus:
     """An ERROR status from the tuner must always populate error_message."""
 

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
@@ -22,32 +22,19 @@ interface AmberTunerTableProps {
   selectedTrial: AmberTunerTrial | null
   setSelectedTrial: (trial: AmberTunerTrial | null) => void
   tunerStopped?: boolean
-  jobFinished?: boolean
   experimentId: string
   simulationPath: string
 }
 
 const AmberTunerTable = (props: AmberTunerTableProps) => {
-  const {
-    rows,
-    selectedTrial,
-    setSelectedTrial,
-    tunerStopped = false,
-    jobFinished = false,
-    experimentId,
-    simulationPath,
-  } = props
+  const { rows, selectedTrial, setSelectedTrial, tunerStopped = false, experimentId, simulationPath } = props
 
   const [confirmChoiceDialog, setConfirmChoiceDialog] = useState(false)
   const [logsTrialId, setLogsTrialId] = useState<string | null>(null)
 
   const { stdout, stderr } = useTunerTrialLogs(experimentId, simulationPath, logsTrialId)
 
-  // Pruned/unmeasured trials are noise for config selection once tuning is done.
-  const visibleRows = useMemo(
-    () => (jobFinished ? rows.filter((r) => r.performance !== null) : rows),
-    [rows, jobFinished]
-  )
+  const visibleRows = rows
 
   const sortedRows = useMemo(() => {
     const statusRank: Record<JobStatus, number> = {
@@ -90,9 +77,7 @@ const AmberTunerTable = (props: AmberTunerTableProps) => {
     return (
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
-          {jobFinished ? (
-            <span>No trial produced a performance measurement.</span>
-          ) : tunerStopped ? (
+          {tunerStopped ? (
             <span>No trials completed. The tuning job was stopped before any trials finished.</span>
           ) : (
             <>

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
@@ -22,17 +22,32 @@ interface AmberTunerTableProps {
   selectedTrial: AmberTunerTrial | null
   setSelectedTrial: (trial: AmberTunerTrial | null) => void
   tunerStopped?: boolean
+  jobFinished?: boolean
   experimentId: string
   simulationPath: string
 }
 
 const AmberTunerTable = (props: AmberTunerTableProps) => {
-  const { rows, selectedTrial, setSelectedTrial, tunerStopped = false, experimentId, simulationPath } = props
+  const {
+    rows,
+    selectedTrial,
+    setSelectedTrial,
+    tunerStopped = false,
+    jobFinished = false,
+    experimentId,
+    simulationPath,
+  } = props
 
   const [confirmChoiceDialog, setConfirmChoiceDialog] = useState(false)
   const [logsTrialId, setLogsTrialId] = useState<string | null>(null)
 
   const { stdout, stderr } = useTunerTrialLogs(experimentId, simulationPath, logsTrialId)
+
+  // Pruned/unmeasured trials are noise for config selection once tuning is done.
+  const visibleRows = useMemo(
+    () => (jobFinished ? rows.filter((r) => r.performance !== null) : rows),
+    [rows, jobFinished]
+  )
 
   const sortedRows = useMemo(() => {
     const statusRank: Record<JobStatus, number> = {
@@ -43,16 +58,16 @@ const AmberTunerTable = (props: AmberTunerTableProps) => {
       UNKNOWN: 4,
     }
 
-    return [...rows].sort((a, b) => {
+    return [...visibleRows].sort((a, b) => {
       if (a.performance === null && b.performance === null) return statusRank[a.status] - statusRank[b.status]
       if (a.performance === null) return 1
       if (b.performance === null) return -1
       if (a.performance !== b.performance) return b.performance - a.performance
       return statusRank[a.status] - statusRank[b.status]
     })
-  }, [rows])
+  }, [visibleRows])
 
-  const trialClasses = useMemo(() => computeTrialClasses(rows), [rows])
+  const trialClasses = useMemo(() => computeTrialClasses(visibleRows), [visibleRows])
 
   const handleRadioClick = useCallback(
     (row: AmberTunerTrial, isOptimal: boolean) => {
@@ -66,11 +81,13 @@ const AmberTunerTable = (props: AmberTunerTableProps) => {
     [selectedTrial, setSelectedTrial]
   )
 
-  if (rows.length === 0) {
+  if (visibleRows.length === 0) {
     return (
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
-          {tunerStopped ? (
+          {jobFinished ? (
+            <span>No trial produced a performance measurement.</span>
+          ) : tunerStopped ? (
             <span>No trials completed. The tuning job was stopped before any trials finished.</span>
           ) : (
             <>

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
@@ -78,7 +78,7 @@ const AmberTunerTable = (props: AmberTunerTableProps) => {
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
           {tunerStopped ? (
-            <span>No trials completed. The tuning job was stopped before any trials finished.</span>
+            <span>No trials have produced a performance measurement.</span>
           ) : (
             <>
               <Loader2 className="h-4 w-4 animate-spin" />

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { Loader2, Terminal } from "lucide-react"
 
@@ -68,6 +68,11 @@ const AmberTunerTable = (props: AmberTunerTableProps) => {
   }, [visibleRows])
 
   const trialClasses = useMemo(() => computeTrialClasses(visibleRows), [visibleRows])
+
+  // A selected trial that becomes hidden (pruned on completion) must not stay active.
+  useEffect(() => {
+    if (selectedTrial && !visibleRows.some((r) => r.id === selectedTrial.id)) setSelectedTrial(null)
+  }, [selectedTrial, visibleRows, setSelectedTrial])
 
   const handleRadioClick = useCallback(
     (row: AmberTunerTrial, isOptimal: boolean) => {

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerView.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerView.tsx
@@ -59,6 +59,8 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
 
   const displayStarted = tunerStarted_condition(tuner)
   const displayStopped = tuner?.is_stopped || false
+  // FINISHED is a terminal tuner-side status: nothing left to stop, only delete.
+  const displayFinished = !displayStopped && tuner?.tuner_status === "FINISHED"
   const trials = (tuner?.trials || []) as AmberTunerTrial[]
   const unavailableReason = simulationLaunchUnavailableReason(simulation ?? null, experiment.engine)
 
@@ -71,11 +73,12 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
             selectedTrial={selectedTrial}
             setSelectedTrial={setSelectedTrial}
             tunerStopped={displayStopped}
+            jobFinished={displayFinished}
             experimentId={experiment.id}
             simulationPath={simulationPath}
           />
 
-          {!displayStopped && (
+          {!displayStopped && !displayFinished && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="default"
@@ -88,7 +91,7 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
             </div>
           )}
 
-          {displayStopped && (
+          {(displayStopped || displayFinished) && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="outline"

--- a/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerView.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/AmberTunerView.tsx
@@ -59,8 +59,6 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
 
   const displayStarted = tunerStarted_condition(tuner)
   const displayStopped = tuner?.is_stopped || false
-  // FINISHED is a terminal tuner-side status: nothing left to stop, only delete.
-  const displayFinished = !displayStopped && tuner?.tuner_status === "FINISHED"
   const trials = (tuner?.trials || []) as AmberTunerTrial[]
   const unavailableReason = simulationLaunchUnavailableReason(simulation ?? null, experiment.engine)
 
@@ -73,12 +71,11 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
             selectedTrial={selectedTrial}
             setSelectedTrial={setSelectedTrial}
             tunerStopped={displayStopped}
-            jobFinished={displayFinished}
             experimentId={experiment.id}
             simulationPath={simulationPath}
           />
 
-          {!displayStopped && !displayFinished && (
+          {!displayStopped && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="default"
@@ -91,7 +88,7 @@ const AmberTunerView = (props: AmberTunerViewProps) => {
             </div>
           )}
 
-          {(displayStopped || displayFinished) && (
+          {displayStopped && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="outline"

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
@@ -22,17 +22,32 @@ interface TunerTableProps {
   selectedTrial: TunerTrial | null
   setSelectedTrial: (trial: TunerTrial | null) => void
   tunerStopped?: boolean
+  jobFinished?: boolean
   experimentId: string
   simulationPath: string
 }
 
 const TunerTable = (props: TunerTableProps) => {
-  const { rows, selectedTrial, setSelectedTrial, tunerStopped = false, experimentId, simulationPath } = props
+  const {
+    rows,
+    selectedTrial,
+    setSelectedTrial,
+    tunerStopped = false,
+    jobFinished = false,
+    experimentId,
+    simulationPath,
+  } = props
 
   const [confirmChoiceDialog, setConfirmChoiceDialog] = useState(false)
   const [logsTrialId, setLogsTrialId] = useState<string | null>(null)
 
   const { stdout, stderr } = useTunerTrialLogs(experimentId, simulationPath, logsTrialId)
+
+  // Pruned/unmeasured trials are noise for config selection once tuning is done.
+  const visibleRows = useMemo(
+    () => (jobFinished ? rows.filter((r) => r.performance !== null) : rows),
+    [rows, jobFinished]
+  )
 
   const sortedRows = useMemo(() => {
     const statusRank: Record<JobStatus, number> = {
@@ -43,16 +58,16 @@ const TunerTable = (props: TunerTableProps) => {
       UNKNOWN: 4,
     }
 
-    return [...rows].sort((a: TunerTrial, b: TunerTrial) => {
+    return [...visibleRows].sort((a: TunerTrial, b: TunerTrial) => {
       if (a.performance === null && b.performance === null) return statusRank[a.status] - statusRank[b.status]
       if (a.performance === null) return 1
       if (b.performance === null) return -1
       if (a.performance !== b.performance) return b.performance - a.performance
       return statusRank[a.status] - statusRank[b.status]
     })
-  }, [rows])
+  }, [visibleRows])
 
-  const trialClasses = useMemo(() => computeTrialClasses(rows), [rows])
+  const trialClasses = useMemo(() => computeTrialClasses(visibleRows), [visibleRows])
 
   const handleRadioClick = useCallback(
     (row: TunerTrial, isOptimal: boolean) => {
@@ -66,11 +81,13 @@ const TunerTable = (props: TunerTableProps) => {
     [selectedTrial, setSelectedTrial]
   )
 
-  if (rows.length === 0) {
+  if (visibleRows.length === 0) {
     return (
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
-          {tunerStopped ? (
+          {jobFinished ? (
+            <span>No trial produced a performance measurement.</span>
+          ) : tunerStopped ? (
             <span>No trials completed. The tuning job was stopped before any trials finished.</span>
           ) : (
             <>

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { Loader2, Terminal } from "lucide-react"
 
@@ -68,6 +68,11 @@ const TunerTable = (props: TunerTableProps) => {
   }, [visibleRows])
 
   const trialClasses = useMemo(() => computeTrialClasses(visibleRows), [visibleRows])
+
+  // A selected trial that becomes hidden (pruned on completion) must not stay active.
+  useEffect(() => {
+    if (selectedTrial && !visibleRows.some((r) => r.id === selectedTrial.id)) setSelectedTrial(null)
+  }, [selectedTrial, visibleRows, setSelectedTrial])
 
   const handleRadioClick = useCallback(
     (row: TunerTrial, isOptimal: boolean) => {

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
@@ -78,7 +78,7 @@ const TunerTable = (props: TunerTableProps) => {
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
           {tunerStopped ? (
-            <span>No trials completed. The tuning job was stopped before any trials finished.</span>
+            <span>No trials have produced a performance measurement.</span>
           ) : (
             <>
               <Loader2 className="h-4 w-4 animate-spin" />

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerTable.tsx
@@ -22,32 +22,19 @@ interface TunerTableProps {
   selectedTrial: TunerTrial | null
   setSelectedTrial: (trial: TunerTrial | null) => void
   tunerStopped?: boolean
-  jobFinished?: boolean
   experimentId: string
   simulationPath: string
 }
 
 const TunerTable = (props: TunerTableProps) => {
-  const {
-    rows,
-    selectedTrial,
-    setSelectedTrial,
-    tunerStopped = false,
-    jobFinished = false,
-    experimentId,
-    simulationPath,
-  } = props
+  const { rows, selectedTrial, setSelectedTrial, tunerStopped = false, experimentId, simulationPath } = props
 
   const [confirmChoiceDialog, setConfirmChoiceDialog] = useState(false)
   const [logsTrialId, setLogsTrialId] = useState<string | null>(null)
 
   const { stdout, stderr } = useTunerTrialLogs(experimentId, simulationPath, logsTrialId)
 
-  // Pruned/unmeasured trials are noise for config selection once tuning is done.
-  const visibleRows = useMemo(
-    () => (jobFinished ? rows.filter((r) => r.performance !== null) : rows),
-    [rows, jobFinished]
-  )
+  const visibleRows = rows
 
   const sortedRows = useMemo(() => {
     const statusRank: Record<JobStatus, number> = {
@@ -90,9 +77,7 @@ const TunerTable = (props: TunerTableProps) => {
     return (
       <div className="flex items-center justify-center rounded-md border p-6">
         <div className="text-muted-foreground flex items-center gap-2 text-sm">
-          {jobFinished ? (
-            <span>No trial produced a performance measurement.</span>
-          ) : tunerStopped ? (
+          {tunerStopped ? (
             <span>No trials completed. The tuning job was stopped before any trials finished.</span>
           ) : (
             <>

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerView.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerView.tsx
@@ -59,8 +59,6 @@ const TunerView = (props: TunerViewProps) => {
 
   const displayStarted = tunerStarted_condition(tuner)
   const displayStopped = tuner?.is_stopped || false
-  // FINISHED is a terminal tuner-side status: nothing left to stop, only delete.
-  const displayFinished = !displayStopped && tuner?.tuner_status === "FINISHED"
   const trials = (tuner?.trials || []) as GmxTunerTrial[]
   const unavailableReason = simulationLaunchUnavailableReason(simulation ?? null, experiment.engine)
 
@@ -73,12 +71,11 @@ const TunerView = (props: TunerViewProps) => {
             selectedTrial={selectedTrial}
             setSelectedTrial={setSelectedTrial}
             tunerStopped={displayStopped}
-            jobFinished={displayFinished}
             experimentId={experiment.id}
             simulationPath={simulationPath}
           />
 
-          {!displayStopped && !displayFinished && (
+          {!displayStopped && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="default"
@@ -91,7 +88,7 @@ const TunerView = (props: TunerViewProps) => {
             </div>
           )}
 
-          {(displayStopped || displayFinished) && (
+          {displayStopped && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="outline"

--- a/dashboard/ui/src/components/Wizard/TuneStep/TunerView.tsx
+++ b/dashboard/ui/src/components/Wizard/TuneStep/TunerView.tsx
@@ -59,6 +59,8 @@ const TunerView = (props: TunerViewProps) => {
 
   const displayStarted = tunerStarted_condition(tuner)
   const displayStopped = tuner?.is_stopped || false
+  // FINISHED is a terminal tuner-side status: nothing left to stop, only delete.
+  const displayFinished = !displayStopped && tuner?.tuner_status === "FINISHED"
   const trials = (tuner?.trials || []) as GmxTunerTrial[]
   const unavailableReason = simulationLaunchUnavailableReason(simulation ?? null, experiment.engine)
 
@@ -71,11 +73,12 @@ const TunerView = (props: TunerViewProps) => {
             selectedTrial={selectedTrial}
             setSelectedTrial={setSelectedTrial}
             tunerStopped={displayStopped}
+            jobFinished={displayFinished}
             experimentId={experiment.id}
             simulationPath={simulationPath}
           />
 
-          {!displayStopped && (
+          {!displayStopped && !displayFinished && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="default"
@@ -88,7 +91,7 @@ const TunerView = (props: TunerViewProps) => {
             </div>
           )}
 
-          {displayStopped && (
+          {(displayStopped || displayFinished) && (
             <div className="flex justify-end gap-2">
               <Button
                 variant="outline"

--- a/docs/superpowers/specs/2026-08-10-tuner-job-status-design.md
+++ b/docs/superpowers/specs/2026-08-10-tuner-job-status-design.md
@@ -21,10 +21,6 @@ Ray does **not** offer a per-task verdict for "cannot be scheduled": the State A
 
 `_submit_trials` writes `RUNNING` the moment a task is *submitted* to Ray, so a trial shows RUNNING while it is actually queued (`PENDING_NODE_ASSIGNMENT`). This spec derives trial and job status from Ray task ground truth instead — the states "as Ray intended": `PENDING_*` → PENDING, `RUNNING*` → RUNNING, terminal states owned by the job thread.
 
-### Early pruning: kept as-is
-
-Batching is load-bearing for the pruner: trials receive `best_steps_per_sec` at submission time, so waves are how later trials learn the settled best. Submitting everything at once would disable pruning; a streaming refill would make pruning decisions race on completion order (non-deterministic). Batches (baseline 3, then 6) are kept, as are the existing `EARLY_STOP_*` constants and threshold semantics. Out of scope for this spec.
-
 ## Goals
 
 - Report honest statuses: a trial shows PENDING wherever it is not executing in Ray (unsubmitted *or* queued); RUNNING only while Ray reports the task executing.
@@ -34,7 +30,7 @@ Batching is load-bearing for the pruner: trials receive `best_steps_per_sec` at 
 ## Non-Goals
 
 - No new statuses: no QUEUED enum anywhere (tuner, dashboard, UI untouched).
-- No changes to grid generation, ordering, batch sizes, or early-stop thresholds.
+- No changes to grid generation, ordering, batch sizes, or early-stop thresholds. Batches (baseline 3, then 6) are load-bearing for the pruner — trials receive `best_steps_per_sec` at submission time — and must not be flattened into a submit-all or streaming-refill loop.
 - No per-trial wedge timer: a wedged RUNNING process that is a batch's last remaining trial is a known, accepted gap (it shows as RUNNING forever). Documented here only.
 - No per-user authorization, no restart-safe active jobs (documented invariants in `tuner/AGENTS.md` remain).
 

--- a/docs/superpowers/specs/2026-08-10-tuner-job-status-design.md
+++ b/docs/superpowers/specs/2026-08-10-tuner-job-status-design.md
@@ -1,0 +1,120 @@
+# Tuner Job Status: Ray-Ground-Truth Trials and Start Watchdog
+
+Date: 2026-08-10
+Component: `tuner/` (tuner-api only; no chart changes; no dashboard/UI changes)
+
+## Background
+
+This spec resulted from a tuner quality review. Findings, and the decisions taken:
+
+### How we know a tuning job has finished
+
+The trial universe is the full generated grid (`engine.generate_configs()`), created as PENDING rows up front, ordered by priority. The job thread walks the list (baseline of 3, then batches of 6) and writes `FINISHED` only when the grid is exhausted. This definition stands unchanged: **FINISHED = every trial reached a terminal state**.
+
+### Schedulability of trials
+
+Configs exceeding `MAX_CPU`/`MAX_GPU` are filtered out at generation, and the chart wires both from the same values as the Ray worker template (`ray.worker.numCpu`/`numGpu`: 32 CPU, 1 GPU per worker, autoscaling 0–5 workers). So every generated config fits a single worker pod by construction, and the KubeRay autoscaler provisions workers on demand. There is no per-trial "unrunnable" class: either the cluster provides workers and every trial eventually runs, or it provides none and nothing runs.
+
+Ray does **not** offer a per-task verdict for "cannot be scheduled": the State API reports `PENDING_NODE_ASSIGNMENT` for both "waiting for autoscaling" and "stuck forever". The only user-visible hang is a job stuck in RUNNING for hours with zero progress because `ray.wait` blocks indefinitely.
+
+### Trial status today is a guess
+
+`_submit_trials` writes `RUNNING` the moment a task is *submitted* to Ray, so a trial shows RUNNING while it is actually queued (`PENDING_NODE_ASSIGNMENT`). This spec derives trial and job status from Ray task ground truth instead — the states "as Ray intended": `PENDING_*` → PENDING, `RUNNING*` → RUNNING, terminal states owned by the job thread.
+
+### Early pruning: kept as-is
+
+Batching is load-bearing for the pruner: trials receive `best_steps_per_sec` at submission time, so waves are how later trials learn the settled best. Submitting everything at once would disable pruning; a streaming refill would make pruning decisions race on completion order (non-deterministic). Batches (baseline 3, then 6) are kept, as are the existing `EARLY_STOP_*` constants and threshold semantics. Out of scope for this spec.
+
+## Goals
+
+- Report honest statuses: a trial shows PENDING wherever it is not executing in Ray (unsubmitted *or* queued); RUNNING only while Ray reports the task executing.
+- Derive the job status from effective trial statuses: PENDING until the first trial executes, RUNNING monotonically after, FINISHED at grid exhaustion, terminal DB states (ERROR stalls/cancels) always win.
+- Bound the two non-terminating paths: cold-start / starvation (nothing ever begins) and mid-run starvation (trials stop beginning) with one watchdog rule.
+
+## Non-Goals
+
+- No new statuses: no QUEUED enum anywhere (tuner, dashboard, UI untouched).
+- No changes to grid generation, ordering, batch sizes, or early-stop thresholds.
+- No per-trial wedge timer: a wedged RUNNING process that is a batch's last remaining trial is a known, accepted gap (it shows as RUNNING forever). Documented here only.
+- No per-user authorization, no restart-safe active jobs (documented invariants in `tuner/AGENTS.md` remain).
+
+## Design
+
+All changes live in `tuner/api/rayworker/tuner.py`, `tuner/api/config.py`, and the two GET-status routers (`routers/gmx.py`, `routers/amber.py`).
+
+### 1. State plumbing
+
+- `JobState.futures` becomes a `future → trial_id` mapping so any code path can map an active Ray task back to its DB trial. `add_futures`/`get_futures`/`remove_future` signatures adjust accordingly. `cancel_job` iterates the map keys — behavior unchanged.
+- `_task_states(job_id) -> dict[int, str]`: for each active future, query the Ray State API (`ray.util.state.get_task(str(future.task_id()), address=...)`) and return `trial_id → task state string`. Bound per call by the active batch size (≤ 6). The dashboard address derives from `RAY_ADDRESS` (head service, dashboard port 8265); reachability from the API pod is already permitted by `tuner-ray` NetworkPolicy (any `tuner`-labeled pod → ray pods, all ports). Query failures or unknown tasks yield *absent* entries — never an exception to the caller.
+- `trial_status_overrides(job_id) -> dict[int, JobStatus]`: built from `_task_states`; a submitted trial whose Ray state starts with `RUNNING` maps to `JobStatus.RUNNING`. This is the only non-terminal override.
+
+### 2. Submission keeps trials PENDING
+
+`_submit_trials` drops its `update_trial_result(trial_id, JobStatus.RUNNING, None)` call. Trials remain PENDING in the DB until the job thread writes a terminal state on completion. Terminal transitions (FINISHED/ERROR, including early-stopped) are written by `_process_trial_results` exactly as today.
+
+### 3. Read-time rendering (both GET status routers)
+
+Before building the trial list in the response, fetch `trial_status_overrides(job_id)` and apply: for a trial whose DB status is PENDING, use the override when present (RUNNING); otherwise keep the DB status. Trials with non-PENDING DB status are never overridden. No DB writes on the read path.
+
+Effective **job** status in the same response — derived, not stored:
+
+- DB status terminal (FINISHED/ERROR) → report as-is.
+- Else, if any effective trial is RUNNING or already terminal → report RUNNING.
+- Else → report PENDING.
+
+This makes job PENDING→RUNNING monotonic at first actual execution and keeps all existing DB writes untouched.
+
+### 4. Start watchdog in `_process_trial_results`
+
+One constant, hardcoded in `tuner/api/config.py` next to `EARLY_STOP_*`:
+
+```python
+TRIAL_START_TIMEOUT_SECONDS = 7200  # 2h; fail job if no trial begins or completes in this window
+```
+
+The wait loop changes from a bare `ray.wait(pending_futures, num_returns=1)` to a ticker-free guarded wait:
+
+```python
+done, pending_futures = ray.wait(pending_futures, num_returns=1, timeout=TRIAL_START_TIMEOUT_SECONDS)
+if not done:
+    states = _task_states(job_id)  # trial_id -> Ray task state, only for pending_futures
+    if any state in states.values() starts with RUNNING:
+        continue  # a trial is executing; extend the window from here
+    # 2h with no completion AND nothing running => nothing began => unschedulable
+```
+
+On the unschedulable path:
+
+1. Log job_id and the remaining trial IDs.
+2. `ray.cancel(future, force=False)` for each remaining future (same teardown as `cancel_job`).
+3. `update_trial_result(trial_id, JobStatus.ERROR, None)` for each remaining trial in the current batch.
+4. Raise `RuntimeError("No trial began or completed within 7200s; cluster busy or unavailable — retry later")`; the existing outer `except` writes job `ERROR` with that message. Trials of never-submitted later batches stay PENDING, which reads honestly.
+
+Why this rule is equivalent to "no progress for 2h": a task that *began* either completes (the wait returns it — including failures, which surface as `RayError` on `get`) or is still executing (visible as RUNNING in the state query). The state check at expiry therefore detects "started" without per-tick polling or transition bookkeeping.
+
+Scenarios:
+
+- Cold start, dead worker pool: everything pending, nothing running → fires at 2h. Realistic provisioning (autoscaler scale-up + large worker image pull) is tens of minutes, so no false fire.
+- Inter-job contention: another user's grid camping the workers looks identical and triggers the same ERROR — intentional; the message says busy-or-unavailable and the user can retry.
+- Slow-but-progressing jobs: any RUNNING trial (or any completion) resets/extends, so they are never killed.
+
+Known accepted gap: a wedged RUNNING process (never advances steps) that becomes a batch's last remaining trial shows RUNNING forever and is not killed by this watchdog.
+
+### 5. Testing
+
+Extend `tuner/tests/rayworker/test_tuner.py` and the router tests:
+
+- Submit keeps trials PENDING (no optimistic RUNNING write).
+- `trial_status_overrides` maps Ray RUNNING states to RUNNING; query failures yield no override; PENDING Ray states yield no override.
+- GET status renders: queued submitted trial → PENDING; Ray-RUNNING trial → RUNNING; terminal DB states never overridden.
+- Derived job status: PENDING before any execution; RUNNING once any effective trial is RUNNING or terminal; terminal DB status wins.
+- Watchdog: empty `ray.wait` + all trials pending/queued → trials ERROR, futures `ray.cancel`ed, job ERROR with the stall message. Empty wait + any RUNNING → loop continues (no DB status changes). `_task_states` failure (no states) treated as "nothing running" → stall path.
+- Existing tests asserting the optimistic RUNNING write are updated to the PENDING contract.
+
+### 6. Docs
+
+Add one paragraph to `tuner/AGENTS.md` noting that trial/job RUNNING reflect Ray task ground truth at read time, and that jobs stall-fail after 2h without a started trial.
+
+### Verification
+
+From repo root: `make fix`, `make type-check`, `make test`.

--- a/tuner/AGENTS.md
+++ b/tuner/AGENTS.md
@@ -26,7 +26,7 @@ Benchmark GROMACS and AMBER execution configurations through a FastAPI service b
 
 - Trials stay PENDING at submission; RUNNING comes from Ray ground truth at read time (`trial_status_overrides` via `ray.util.state.get_task`) — a trial shows RUNNING only while Ray reports the task executing. Only PENDING trials may be overridden; terminal states are owned by the job thread.
 - Job status is derived at read time: PENDING until the first trial executes, RUNNING monotonically after, FINISHED/ERROR from the DB always win.
-- Start watchdog: no completion for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded in `config.py`) with nothing RUNNING in Ray means the batch never became schedulable — trials are cancelled, marked ERROR, the job fails with "cluster busy or unavailable". Executing trials extend the window.
+- Start watchdog: no completion for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded in `config.py`) with nothing RUNNING in Ray means the batch never became schedulable — futures are cancelled and the job fails with "cluster busy or unavailable". Executing trials extend the window; a State API outage also extends (never a false kill). Terminal jobs never leave PENDING trials behind: `_error_pending_trials` sweeps them to ERROR on any failure path.
 
 ## Restart Semantics
 

--- a/tuner/AGENTS.md
+++ b/tuner/AGENTS.md
@@ -26,6 +26,7 @@ Benchmark GROMACS and AMBER execution configurations through a FastAPI service b
 
 - Trials stay PENDING at submission; RUNNING comes from Ray ground truth at read time (`trial_status_overrides` via one filtered `ray.util.state.list_tasks` query) — a trial shows RUNNING only while Ray reports the task executing. Only PENDING trials may be overridden; terminal states are owned by the job thread.
 - Job status is derived at read time: PENDING until the first trial executes, RUNNING monotonically after, FINISHED/ERROR from the DB always win.
+- Pruning is dual-axis: a trial is early-stopped only when it is both slower than `EARLY_STOP_THRESHOLD` of the fastest champion AND costlier per step than `EARLY_STOP_COST_RATIO` × the cheapest champion (`cost_per_step = footprint.hourly_cost() / steps_per_sec`). Champions are tracked independently, so the fastest and the most efficient config are both always kept.
 - Start watchdog: no completion for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded in `config.py`) with nothing RUNNING in Ray means the batch never became schedulable — futures are cancelled and the job fails with "cluster busy or unavailable". Executing trials extend the window; a State API outage also extends (never a false kill). Terminal jobs never leave PENDING trials behind: `_error_pending_trials` sweeps them to ERROR on any failure path.
 
 ## Ray Client Mode Gotchas

--- a/tuner/AGENTS.md
+++ b/tuner/AGENTS.md
@@ -22,6 +22,12 @@ Benchmark GROMACS and AMBER execution configurations through a FastAPI service b
 - Never add the worker to root aggregate build/push targets or GitHub Actions.
 - The chart must consume the complete worker image reference from `config*.yaml` without applying the MDDash release tag.
 
+## Status Semantics
+
+- Trials stay PENDING at submission; RUNNING comes from Ray ground truth at read time (`trial_status_overrides` via `ray.util.state.get_task`) — a trial shows RUNNING only while Ray reports the task executing. Only PENDING trials may be overridden; terminal states are owned by the job thread.
+- Job status is derived at read time: PENDING until the first trial executes, RUNNING monotonically after, FINISHED/ERROR from the DB always win.
+- Start watchdog: no completion for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded in `config.py`) with nothing RUNNING in Ray means the batch never became schedulable — trials are cancelled, marked ERROR, the job fails with "cluster busy or unavailable". Executing trials extend the window.
+
 ## Restart Semantics
 
 Active threads, cancellation events, and Ray object references are process-local. API restarts can leave remote work orphaned and mark persisted active jobs as failed. Do not claim restart-safe active jobs without a separate durable reconciliation design.

--- a/tuner/AGENTS.md
+++ b/tuner/AGENTS.md
@@ -24,9 +24,18 @@ Benchmark GROMACS and AMBER execution configurations through a FastAPI service b
 
 ## Status Semantics
 
-- Trials stay PENDING at submission; RUNNING comes from Ray ground truth at read time (`trial_status_overrides` via `ray.util.state.get_task`) — a trial shows RUNNING only while Ray reports the task executing. Only PENDING trials may be overridden; terminal states are owned by the job thread.
+- Trials stay PENDING at submission; RUNNING comes from Ray ground truth at read time (`trial_status_overrides` via one filtered `ray.util.state.list_tasks` query) — a trial shows RUNNING only while Ray reports the task executing. Only PENDING trials may be overridden; terminal states are owned by the job thread.
 - Job status is derived at read time: PENDING until the first trial executes, RUNNING monotonically after, FINISHED/ERROR from the DB always win.
 - Start watchdog: no completion for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded in `config.py`) with nothing RUNNING in Ray means the batch never became schedulable — futures are cancelled and the job fails with "cluster busy or unavailable". Executing trials extend the window; a State API outage also extends (never a false kill). Terminal jobs never leave PENDING trials behind: `_error_pending_trials` sweeps them to ERROR on any failure path.
+
+## Ray Client Mode Gotchas
+
+- The job thread connects via `ray.init("ray://...")`. Ray's `ClientContext.connect` is not thread-safe: concurrent first inits corrupt the client (`'NoneType' object has no attribute 'connection_info'`). All init goes through `_ensure_ray_initialized` under a lock; never call `ray.init` directly.
+- Ray SDK address resolution (`get_address_for_submission_client`) overrides any explicit address with the `RAY_ADDRESS` env var, and a `ray://` address triggers a full client connect/disconnect cycle just to discover the dashboard URL — that raced job inits in production. `config.py` pins `RAY_API_SERVER_ADDRESS` to the dashboard HTTP URL so State API calls (`list_tasks`, `SubmissionClient`) stay pure-HTTP. Never `ray.init` with a dashboard (`http://`) address.
+
+## Verification
+
+- Unit tests (`make test`) mock Ray entirely, so they cannot catch client-mode races, SDK address resolution, or dashboard reachability. For any change touching Ray interaction, push the image (`make push-tuner-api ENV=dev`) and run the live suite: `make -C tuner e2e ENV=dev` (port-forwards into the dev namespace and runs a real short tuning job end to end).
 
 ## Restart Semantics
 

--- a/tuner/CLAUDE.md
+++ b/tuner/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tuner/api/config.py
+++ b/tuner/api/config.py
@@ -12,11 +12,8 @@ MAX_CPU = int(os.getenv("MAX_CPU", "32"))
 MAX_GPU = int(os.getenv("MAX_GPU", "1"))
 
 RAY_ADDRESS = os.getenv("RAY_ADDRESS", "ray://tuner-raycluster-head-svc:10001")
-# State API SDK address resolution overrides any explicit address with the RAY_ADDRESS env
-# var, and a ray:// address triggers a full Ray Client ray.init()/disconnect() cycle just to
-# discover the dashboard URL (ray_client_address_to_api_server_url). Those cycles race job
-# threads' ray.init and crash them. RAY_API_SERVER_ADDRESS has the highest priority, so
-# pinning it keeps State API queries pure-HTTP.
+# Pin RAY_API_SERVER_ADDRESS so State API queries stay pure-HTTP; otherwise the SDK resolves
+# ray:// addresses by opening a full Ray Client connection, which races job-thread ray.init.
 RAY_DASHBOARD_ADDRESS = f"http://{RAY_ADDRESS.removeprefix('ray://').split(':')[0]}:8265"
 os.environ.setdefault("RAY_API_SERVER_ADDRESS", RAY_DASHBOARD_ADDRESS)
 

--- a/tuner/api/config.py
+++ b/tuner/api/config.py
@@ -33,6 +33,9 @@ EARLY_STOP_CHECK_INTERVAL = 10.0  # Seconds between checks
 EARLY_STOP_BASELINE_TRIALS = 3  # Initial trials to establish baseline
 EARLY_STOP_BATCH_SIZE = 6  # Parallel batch size for remaining trials
 
+# Fail the job if no trial begins or completes within this window (cluster busy/unavailable).
+TRIAL_START_TIMEOUT_SECONDS = 7200
+
 RUNTIME_WORKDIR = os.getenv(
     "RUNTIME_WORKDIR",
     str(Path(__file__).resolve().parent.parent),

--- a/tuner/api/config.py
+++ b/tuner/api/config.py
@@ -12,6 +12,13 @@ MAX_CPU = int(os.getenv("MAX_CPU", "32"))
 MAX_GPU = int(os.getenv("MAX_GPU", "1"))
 
 RAY_ADDRESS = os.getenv("RAY_ADDRESS", "ray://tuner-raycluster-head-svc:10001")
+# State API SDK address resolution overrides any explicit address with the RAY_ADDRESS env
+# var, and a ray:// address triggers a full Ray Client ray.init()/disconnect() cycle just to
+# discover the dashboard URL (ray_client_address_to_api_server_url). Those cycles race job
+# threads' ray.init and crash them. RAY_API_SERVER_ADDRESS has the highest priority, so
+# pinning it keeps State API queries pure-HTTP.
+RAY_DASHBOARD_ADDRESS = f"http://{RAY_ADDRESS.removeprefix('ray://').split(':')[0]}:8265"
+os.environ.setdefault("RAY_API_SERVER_ADDRESS", RAY_DASHBOARD_ADDRESS)
 
 NTOMP_OPTIONS = [1, 2, 4]
 NP_OPTIONS = [1, 2, 4]

--- a/tuner/api/config.py
+++ b/tuner/api/config.py
@@ -30,7 +30,8 @@ MAX_REQUEST_SIZE = int(os.getenv("MAX_REQUEST_SIZE", str(MAX_UPLOAD_SIZE * 3))) 
 
 # Early stopping config
 EARLY_STOP_ENABLED = True
-EARLY_STOP_THRESHOLD = 0.65  # Stop if <65% of best trial
+EARLY_STOP_THRESHOLD = 0.75  # Stop if <75% of fastest trial
+EARLY_STOP_COST_RATIO = 1.5  # ...AND cost-per-step >150% of cheapest trial (both required to prune)
 EARLY_STOP_WARMUP_STEPS = 5000  # Steps before evaluating
 EARLY_STOP_WARMUP_SECONDS = 60.0  # Seconds before evaluating (fallback)
 EARLY_STOP_CHECK_INTERVAL = 10.0  # Seconds between checks

--- a/tuner/api/engines/amber/engine.py
+++ b/tuner/api/engines/amber/engine.py
@@ -31,17 +31,15 @@ class AmberEngine:
         nsteps: int,
         extra_args: str,
         best_steps_per_sec: float,
+        best_cost_per_step: float,
     ) -> TrialResult:
         """Execute one pmemd trial and return the result."""
+        amber_config = AmberTrialConfig.from_dict(config.params)
         perf, sps, early = run_pmemd(
-            AmberTrialConfig.from_dict(config.params),
-            trial_id,
-            job_id,
-            extra_args,
-            nsteps,
-            best_steps_per_sec,
+            amber_config, trial_id, job_id, extra_args, nsteps, best_steps_per_sec, best_cost_per_step
         )
-        return TrialResult(performance=perf, steps_per_sec=sps, early_stopped=early)
+        cost = amber_config.footprint.hourly_cost() / sps if sps > 0 else 0.0
+        return TrialResult(performance=perf, steps_per_sec=sps, early_stopped=early, cost_per_step=cost)
 
     def simulation_length_ns(self, job_id: str, nsteps_override: int | None = None) -> float | None:  # ruff: ignore[unused-method-argument]
         """Parse nstlim * dt from the job's original uploaded mdin file (pmemd has no step-count CLI override)."""

--- a/tuner/api/engines/amber/runner.py
+++ b/tuner/api/engines/amber/runner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from api.config import (
     EARLY_STOP_CHECK_INTERVAL,
+    EARLY_STOP_COST_RATIO,
     EARLY_STOP_ENABLED,
     EARLY_STOP_THRESHOLD,
     EARLY_STOP_WARMUP_SECONDS,
@@ -34,6 +35,7 @@ def run_pmemd(
     extra_args: str = "",
     nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
+    best_cost_per_step: float = 0.0,
 ) -> tuple[float, float, bool]:
     """
     Execute pmemd with the given config and return (performance_ns_day, steps_per_sec, early_stopped).
@@ -66,7 +68,17 @@ def run_pmemd(
     if extra_args:
         cmd += shlex.split(extra_args)
 
-    result = _run_command_with_monitoring(cmd, mdout, mdinfo, trial_dir, f"Trial {trial_id}", best_steps_per_sec, env)
+    result = _run_command_with_monitoring(
+        cmd,
+        mdout,
+        mdinfo,
+        trial_dir,
+        f"Trial {trial_id}",
+        best_steps_per_sec,
+        env,
+        config.footprint.hourly_cost(),
+        best_cost_per_step,
+    )
     if result is None:
         return 0.0, 0.0, False
 
@@ -139,6 +151,8 @@ def _run_command_with_monitoring(
     context: str,
     best_steps_per_sec: float,
     env: dict[str, str],
+    hourly_cost: float,
+    best_cost_per_step: float,
 ) -> tuple[bool, float] | None:
     stdout_path = cwd / "stdout.log"
     stderr_path = cwd / "stderr.log"
@@ -157,7 +171,7 @@ def _run_command_with_monitoring(
             ) as process,
         ):
             try:
-                result = _monitor_process(process, mdinfo, context, best_steps_per_sec)
+                result = _monitor_process(process, mdinfo, context, best_steps_per_sec, hourly_cost, best_cost_per_step)
             finally:
                 _stop_process_group(process)
         if result is None:
@@ -198,6 +212,8 @@ def _monitor_process(
     mdinfo: Path,
     context: str,
     best_steps_per_sec: float,
+    hourly_cost: float,
+    best_cost_per_step: float,
 ) -> tuple[bool, float] | None:
     start_time = time.time()
     last_step = 0
@@ -216,13 +232,17 @@ def _monitor_process(
         if elapsed > 0:
             steps_per_sec = current_step / elapsed
 
-        if _should_early_stop(current_step, elapsed, steps_per_sec, best_steps_per_sec):
+        cost_per_step = hourly_cost / steps_per_sec if steps_per_sec > 0 else float("inf")
+        if _should_early_stop(
+            current_step, elapsed, steps_per_sec, best_steps_per_sec, cost_per_step, best_cost_per_step
+        ):
             logger.info(
-                "%s: early stopping at step %d (%.1f steps/s < %.1f threshold)",
+                "%s: early stopping at step %d (%.1f steps/s too slow, cost/step %.4f > %.4f)",
                 context,
                 current_step,
                 steps_per_sec,
-                best_steps_per_sec * EARLY_STOP_THRESHOLD,
+                cost_per_step,
+                best_cost_per_step * EARLY_STOP_COST_RATIO,
             )
             _terminate_process_group(process, signal.SIGTERM)
             early_stopped = True
@@ -252,8 +272,18 @@ def _monitor_process(
     return early_stopped, steps_per_sec
 
 
-def _should_early_stop(current_step: int, elapsed_time: float, steps_per_sec: float, best_steps_per_sec: float) -> bool:
-    if best_steps_per_sec <= 0:
+def _should_early_stop(
+    current_step: int,
+    elapsed_time: float,
+    steps_per_sec: float,
+    best_steps_per_sec: float,
+    cost_per_step: float,
+    best_cost_per_step: float,
+) -> bool:
+    """Prune only trials both slower and more expensive per step than the champions."""
+    if best_steps_per_sec <= 0 or best_cost_per_step <= 0:
         return False
     warmup_reached = (current_step >= EARLY_STOP_WARMUP_STEPS) or (elapsed_time >= EARLY_STOP_WARMUP_SECONDS)
-    return EARLY_STOP_ENABLED and warmup_reached and steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
+    too_slow = steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
+    too_expensive = cost_per_step > best_cost_per_step * EARLY_STOP_COST_RATIO
+    return EARLY_STOP_ENABLED and warmup_reached and too_slow and too_expensive

--- a/tuner/api/engines/amber/runner.py
+++ b/tuner/api/engines/amber/runner.py
@@ -11,18 +11,10 @@ import subprocess
 import time
 from pathlib import Path
 
-from api.config import (
-    EARLY_STOP_CHECK_INTERVAL,
-    EARLY_STOP_COST_RATIO,
-    EARLY_STOP_ENABLED,
-    EARLY_STOP_THRESHOLD,
-    EARLY_STOP_WARMUP_SECONDS,
-    EARLY_STOP_WARMUP_STEPS,
-    INPUTS_DIR,
-    JOBS_DIR,
-)
+from api.config import EARLY_STOP_CHECK_INTERVAL, EARLY_STOP_COST_RATIO, INPUTS_DIR, JOBS_DIR
 from api.engines.amber.config import AmberBinary, AmberTrialConfig
 from api.engines.amber.mdin import patch_mdin_for_benchmark
+from api.engines.early_stop import _should_early_stop
 from api.utils import tail
 
 logger = logging.getLogger(__name__)
@@ -270,20 +262,3 @@ def _monitor_process(
         return None
 
     return early_stopped, steps_per_sec
-
-
-def _should_early_stop(
-    current_step: int,
-    elapsed_time: float,
-    steps_per_sec: float,
-    best_steps_per_sec: float,
-    cost_per_step: float,
-    best_cost_per_step: float,
-) -> bool:
-    """Prune only trials both slower and more expensive per step than the champions."""
-    if best_steps_per_sec <= 0 or best_cost_per_step <= 0:
-        return False
-    warmup_reached = (current_step >= EARLY_STOP_WARMUP_STEPS) or (elapsed_time >= EARLY_STOP_WARMUP_SECONDS)
-    too_slow = steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
-    too_expensive = cost_per_step > best_cost_per_step * EARLY_STOP_COST_RATIO
-    return EARLY_STOP_ENABLED and warmup_reached and too_slow and too_expensive

--- a/tuner/api/engines/early_stop.py
+++ b/tuner/api/engines/early_stop.py
@@ -1,0 +1,26 @@
+"""Shared early-stop predicate for tuning trials, used by all engine runners."""
+
+from api.config import (
+    EARLY_STOP_COST_RATIO,
+    EARLY_STOP_ENABLED,
+    EARLY_STOP_THRESHOLD,
+    EARLY_STOP_WARMUP_SECONDS,
+    EARLY_STOP_WARMUP_STEPS,
+)
+
+
+def _should_early_stop(
+    current_step: int,
+    elapsed_time: float,
+    steps_per_sec: float,
+    best_steps_per_sec: float,
+    cost_per_step: float,
+    best_cost_per_step: float,
+) -> bool:
+    """Prune only trials both slower and more expensive per step than the champions."""
+    if best_steps_per_sec <= 0 or best_cost_per_step <= 0:
+        return False
+    warmup_reached = (current_step >= EARLY_STOP_WARMUP_STEPS) or (elapsed_time >= EARLY_STOP_WARMUP_SECONDS)
+    too_slow = steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
+    too_expensive = cost_per_step > best_cost_per_step * EARLY_STOP_COST_RATIO
+    return EARLY_STOP_ENABLED and warmup_reached and too_slow and too_expensive

--- a/tuner/api/engines/gmx/engine.py
+++ b/tuner/api/engines/gmx/engine.py
@@ -33,17 +33,15 @@ class GmxEngine:
         nsteps: int,
         extra_args: str,
         best_steps_per_sec: float,
+        best_cost_per_step: float,
     ) -> TrialResult:
         """Execute one mdrun trial and return the result."""
+        gmx_config = GmxTrialConfig.from_dict(config.params)
         perf, sps, early = run_mdrun(
-            GmxTrialConfig.from_dict(config.params),
-            trial_id,
-            job_id,
-            extra_args,
-            nsteps,
-            best_steps_per_sec,
+            gmx_config, trial_id, job_id, extra_args, nsteps, best_steps_per_sec, best_cost_per_step
         )
-        return TrialResult(performance=perf, steps_per_sec=sps, early_stopped=early)
+        cost = gmx_config.footprint.hourly_cost() / sps if sps > 0 else 0.0
+        return TrialResult(performance=perf, steps_per_sec=sps, early_stopped=early, cost_per_step=cost)
 
     def simulation_length_ns(self, job_id: str, nsteps_override: int | None = None) -> float | None:
         """Extract nsteps * delta_t from the job's .tpr via `gmx dump` on a Ray worker; -nsteps override wins."""

--- a/tuner/api/engines/gmx/runner.py
+++ b/tuner/api/engines/gmx/runner.py
@@ -11,16 +11,8 @@ import subprocess
 import time
 from pathlib import Path
 
-from api.config import (
-    EARLY_STOP_CHECK_INTERVAL,
-    EARLY_STOP_COST_RATIO,
-    EARLY_STOP_ENABLED,
-    EARLY_STOP_THRESHOLD,
-    EARLY_STOP_WARMUP_SECONDS,
-    EARLY_STOP_WARMUP_STEPS,
-    INPUTS_DIR,
-    JOBS_DIR,
-)
+from api.config import EARLY_STOP_CHECK_INTERVAL, EARLY_STOP_COST_RATIO, INPUTS_DIR, JOBS_DIR
+from api.engines.early_stop import _should_early_stop
 from api.engines.gmx.config import GmxTrialConfig, PMEMode
 from api.utils import tail
 
@@ -219,27 +211,6 @@ def _stop_process_group(process: subprocess.Popen) -> None:
     except subprocess.TimeoutExpired:
         _terminate_process_group(process, signal.SIGKILL)
         process.wait()
-
-
-def _should_early_stop(
-    current_step: int,
-    elapsed_time: float,
-    steps_per_sec: float,
-    best_steps_per_sec: float,
-    cost_per_step: float,
-    best_cost_per_step: float,
-) -> bool:
-    """Prune only trials both slower and more expensive per step than the champions."""
-    if best_steps_per_sec <= 0 or best_cost_per_step <= 0:
-        return False
-
-    # Kick in if we've reached step threshold OR if we've been running long enough to have a stable reading
-    warmup_reached = (current_step >= EARLY_STOP_WARMUP_STEPS) or (elapsed_time >= EARLY_STOP_WARMUP_SECONDS)
-
-    too_slow = steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
-    # cost_per_step=inf (zero measured progress) stays eligible to stop: it's also too slow.
-    too_expensive = cost_per_step > best_cost_per_step * EARLY_STOP_COST_RATIO
-    return EARLY_STOP_ENABLED and warmup_reached and too_slow and too_expensive
 
 
 def _monitor_process(

--- a/tuner/api/engines/gmx/runner.py
+++ b/tuner/api/engines/gmx/runner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from api.config import (
     EARLY_STOP_CHECK_INTERVAL,
+    EARLY_STOP_COST_RATIO,
     EARLY_STOP_ENABLED,
     EARLY_STOP_THRESHOLD,
     EARLY_STOP_WARMUP_SECONDS,
@@ -33,6 +34,7 @@ def run_mdrun(
     extra_args: str = "",
     nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
+    best_cost_per_step: float = 0.0,
 ) -> tuple[float, float, bool]:
     """
     Execute GROMACS mdrun with the given config and return performance.
@@ -64,7 +66,15 @@ def run_mdrun(
     stderr_log = trial_dir / "stderr.log"
 
     result = _run_command_with_monitoring(
-        cmd, stdout_log, stderr_log, env, trial_dir, f"Trial {trial_id}", best_steps_per_sec
+        cmd,
+        stdout_log,
+        stderr_log,
+        env,
+        trial_dir,
+        f"Trial {trial_id}",
+        best_steps_per_sec,
+        config.footprint.hourly_cost(),
+        best_cost_per_step,
     )
     if result is None:
         return 0.0, 0.0, False
@@ -143,6 +153,8 @@ def _run_command_with_monitoring(
     cwd: Path,
     context: str,
     best_steps_per_sec: float,
+    hourly_cost: float,
+    best_cost_per_step: float,
 ) -> tuple[bool, float] | None:
     """
     Run a subprocess with progress monitoring and early stopping.
@@ -155,6 +167,7 @@ def _run_command_with_monitoring(
         cwd: Working directory
         context: Description for logging
         best_steps_per_sec: Best steps/sec observed (for early stopping comparison)
+        hourly_cost: This trial's footprint cost per hour (for cost-per-step pruning)
 
     Returns:
         Tuple of (early_stopped, final_steps_per_sec) on success, None on failure.
@@ -171,7 +184,9 @@ def _run_command_with_monitoring(
                 start_new_session=True,  # Create new session for clean termination
             )
             try:
-                return _monitor_process(process, stderr_log, context, best_steps_per_sec)
+                return _monitor_process(
+                    process, stderr_log, context, best_steps_per_sec, hourly_cost, best_cost_per_step
+                )
             finally:
                 _stop_process_group(process)
 
@@ -204,15 +219,25 @@ def _stop_process_group(process: subprocess.Popen) -> None:
         process.wait()
 
 
-def _should_early_stop(current_step: int, elapsed_time: float, steps_per_sec: float, best_steps_per_sec: float) -> bool:
-    """Determine if early stopping criteria are met."""
-    if best_steps_per_sec <= 0:
+def _should_early_stop(
+    current_step: int,
+    elapsed_time: float,
+    steps_per_sec: float,
+    best_steps_per_sec: float,
+    cost_per_step: float,
+    best_cost_per_step: float,
+) -> bool:
+    """Prune only trials both slower and more expensive per step than the champions."""
+    if best_steps_per_sec <= 0 or best_cost_per_step <= 0:
         return False
 
     # Kick in if we've reached step threshold OR if we've been running long enough to have a stable reading
     warmup_reached = (current_step >= EARLY_STOP_WARMUP_STEPS) or (elapsed_time >= EARLY_STOP_WARMUP_SECONDS)
 
-    return EARLY_STOP_ENABLED and warmup_reached and steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
+    too_slow = steps_per_sec < best_steps_per_sec * EARLY_STOP_THRESHOLD
+    # cost_per_step=inf (zero measured progress) stays eligible to stop: it's also too slow.
+    too_expensive = cost_per_step > best_cost_per_step * EARLY_STOP_COST_RATIO
+    return EARLY_STOP_ENABLED and warmup_reached and too_slow and too_expensive
 
 
 def _monitor_process(
@@ -220,6 +245,8 @@ def _monitor_process(
     stderr_log: Path,
     context: str,
     best_steps_per_sec: float,
+    hourly_cost: float,
+    best_cost_per_step: float,
 ) -> tuple[bool, float] | None:
     """Monitor process execution and apply early stopping if needed."""
     start_time = time.time()
@@ -238,13 +265,17 @@ def _monitor_process(
         if elapsed > 0:
             steps_per_sec = current_step / elapsed
 
-        if _should_early_stop(current_step, elapsed, steps_per_sec, best_steps_per_sec):
+        cost_per_step = hourly_cost / steps_per_sec if steps_per_sec > 0 else float("inf")
+        if _should_early_stop(
+            current_step, elapsed, steps_per_sec, best_steps_per_sec, cost_per_step, best_cost_per_step
+        ):
             logger.info(
-                "%s: early stopping at step %d (%.1f steps/s < %.1f threshold)",
+                "%s: early stopping at step %d (%.1f steps/s too slow, cost/step %.4f > %.4f)",
                 context,
                 current_step,
                 steps_per_sec,
-                best_steps_per_sec * EARLY_STOP_THRESHOLD,
+                cost_per_step,
+                best_cost_per_step * EARLY_STOP_COST_RATIO,
             )
             _terminate_process_group(process, signal.SIGTERM)
             early_stopped = True

--- a/tuner/api/engines/gmx/runner.py
+++ b/tuner/api/engines/gmx/runner.py
@@ -46,6 +46,7 @@ def run_mdrun(
         extra_args: Additional mdrun arguments
         nsteps: Number of steps to run
         best_steps_per_sec: Best steps/sec observed so far (for early stopping)
+        best_cost_per_step: Cheapest cost per step observed so far (for early stopping)
 
     Returns:
         Tuple of (performance_ns_day, steps_per_sec, early_stopped).
@@ -168,6 +169,7 @@ def _run_command_with_monitoring(
         context: Description for logging
         best_steps_per_sec: Best steps/sec observed (for early stopping comparison)
         hourly_cost: This trial's footprint cost per hour (for cost-per-step pruning)
+        best_cost_per_step: Cheapest cost per step observed so far (for early stopping)
 
     Returns:
         Tuple of (early_stopped, final_steps_per_sec) on success, None on failure.

--- a/tuner/api/engines/protocol.py
+++ b/tuner/api/engines/protocol.py
@@ -21,6 +21,7 @@ class TrialResult:
     performance: float  # ns/day; 0.0 on failure
     steps_per_sec: float  # used for early stopping comparison
     early_stopped: bool
+    cost_per_step: float = 0.0  # footprint hourly rate / steps_per_sec; 0.0 if steps unknown
 
 
 class Engine(Protocol):
@@ -38,6 +39,7 @@ class Engine(Protocol):
         nsteps: int,
         extra_args: str,
         best_steps_per_sec: float,
+        best_cost_per_step: float,
     ) -> TrialResult:
         """Execute a single trial and return its performance result."""
         ...

--- a/tuner/api/rayworker/__init__.py
+++ b/tuner/api/rayworker/__init__.py
@@ -1,5 +1,11 @@
 """Ray worker code for MD engine tuning."""
 
-from api.rayworker.tuner import cancel_job, submit_tuning_job, sync_job_status
+from api.rayworker.tuner import (
+    cancel_job,
+    derive_job_status,
+    submit_tuning_job,
+    sync_job_status,
+    trial_status_overrides,
+)
 
-__all__ = ["cancel_job", "submit_tuning_job", "sync_job_status"]
+__all__ = ["cancel_job", "derive_job_status", "submit_tuning_job", "sync_job_status", "trial_status_overrides"]

--- a/tuner/api/rayworker/tuner.py
+++ b/tuner/api/rayworker/tuner.py
@@ -170,10 +170,11 @@ def _run_single_trial(
     extra_args: str,
     nsteps: int = 25_000,
     best_steps_per_sec: float = 0.0,
+    best_cost_per_step: float = 0.0,
 ) -> dict[str, Any]:
     """Execute a single trial on a Ray worker."""
     logger.info("Running trial %s: params=%s, nsteps=%d", trial_id, config.params, nsteps)
-    result = engine.run_trial(config, trial_id, job_id, nsteps, extra_args, best_steps_per_sec)
+    result = engine.run_trial(config, trial_id, job_id, nsteps, extra_args, best_steps_per_sec, best_cost_per_step)
     status = JobStatus.FINISHED if result.performance > 0 or result.early_stopped else JobStatus.ERROR
     logger.info(
         "Trial %s completed: status=%s, performance=%.2f ns/day, steps/sec=%.1f",
@@ -188,6 +189,7 @@ def _run_single_trial(
         "performance": result.performance,
         "steps_per_sec": result.steps_per_sec,
         "early_stopped": result.early_stopped,
+        "cost_per_step": result.cost_per_step,
     }
 
 
@@ -202,6 +204,7 @@ def _submit_trials(
     engine: Engine,
     nsteps: int,
     best_steps_per_sec: float,
+    best_cost_per_step: float,
 ) -> dict[ray.ObjectRef, int]:
     future_to_trial: dict[ray.ObjectRef, int] = {}
     for trial_id, cfg in trials:
@@ -213,6 +216,7 @@ def _submit_trials(
             extra_args,
             nsteps,  # ty: ignore[too-many-positional-arguments]  # Ray stub omits optional params.
             best_steps_per_sec,
+            best_cost_per_step,
         )
         future_to_trial[future] = trial_id
     # Trials stay PENDING until Ray reports RUNNING or the wait loop writes a terminal state.
@@ -248,9 +252,10 @@ def _process_trial_results(
     job_id: str,
     future_to_trial: dict[ray.ObjectRef, int],
     best_steps_per_sec: float,
-) -> float:
+    best_cost_per_step: float,
+) -> tuple[float, float]:
     pending_futures = list(future_to_trial.keys())
-    new_best = best_steps_per_sec
+    best = (best_steps_per_sec, best_cost_per_step)
 
     while pending_futures:
         done, pending_futures = ray.wait(pending_futures, num_returns=1, timeout=TRIAL_START_TIMEOUT_SECONDS)
@@ -265,9 +270,13 @@ def _process_trial_results(
                 perf_value = None if early_stopped else res.get("performance")
                 update_trial_result(trial_id, res.get("status", JobStatus.ERROR), perf_value)
                 steps_per_sec = res.get("steps_per_sec", 0.0)
-                if steps_per_sec > new_best and not early_stopped:
-                    new_best = steps_per_sec
-                    logger.info("Job %s: New best steps/sec: %.1f", job_id, new_best)
+                cost_per_step = res.get("cost_per_step", 0.0)
+                if steps_per_sec > best[0] and not early_stopped:
+                    best = (steps_per_sec, best[1])
+                    logger.info("Job %s: New best steps/sec: %.1f", job_id, steps_per_sec)
+                if 0 < cost_per_step < (best[1] or float("inf")) and not early_stopped:
+                    best = (best[0], cost_per_step)
+                    logger.info("Job %s: New best cost/step: %.4f", job_id, cost_per_step)
             else:
                 logger.warning("Trial %d returned no result", trial_id)
                 update_trial_result(trial_id, JobStatus.ERROR, None)
@@ -277,7 +286,7 @@ def _process_trial_results(
         finally:
             _job_context.remove_future(job_id, done[0])
 
-    return new_best
+    return best
 
 
 def _run_tuning_async(
@@ -298,15 +307,15 @@ def _run_tuning_async(
         except Exception:
             logger.warning("Failed to extract simulation length for job %s", job_id, exc_info=True)
 
-        best_steps_per_sec = 0.0
+        best_steps, best_cost = 0.0, 0.0
 
         baseline_count = min(EARLY_STOP_BASELINE_TRIALS, len(trial_configs))
         baseline_trials = trial_configs[:baseline_count]
         remaining_trials = trial_configs[baseline_count:]
 
         if baseline_trials:
-            future_to_trial = _submit_trials(job_id, extra_args, baseline_trials, engine, nsteps, best_steps_per_sec)
-            best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, extra_args, baseline_trials, engine, nsteps, best_steps, best_cost)
+            best_steps, best_cost = _process_trial_results(job_id, future_to_trial, best_steps, best_cost)
 
         batch_size = max(1, EARLY_STOP_BATCH_SIZE)
         for idx in range(0, len(remaining_trials), batch_size):
@@ -314,13 +323,13 @@ def _run_tuning_async(
                 logger.info("Job %s cancelled, skipping remaining trials", job_id)
                 break
             batch = remaining_trials[idx : idx + batch_size]
-            future_to_trial = _submit_trials(job_id, extra_args, batch, engine, nsteps, best_steps_per_sec)
-            best_steps_per_sec = _process_trial_results(job_id, future_to_trial, best_steps_per_sec)
+            future_to_trial = _submit_trials(job_id, extra_args, batch, engine, nsteps, best_steps, best_cost)
+            best_steps, best_cost = _process_trial_results(job_id, future_to_trial, best_steps, best_cost)
 
         if _job_context.is_cancelled(job_id):
             logger.info("Job %s finished after cancellation; status already set", job_id)
         else:
-            logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps_per_sec)
+            logger.info("All trials completed for job %s (best: %.1f steps/s)", job_id, best_steps)
             if not _job_context.is_cancelled(job_id):
                 update_job_status(job_id, JobStatus.FINISHED)
     except Exception:

--- a/tuner/api/rayworker/tuner.py
+++ b/tuner/api/rayworker/tuner.py
@@ -13,6 +13,7 @@ from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
     EARLY_STOP_BATCH_SIZE,
     RAY_ADDRESS,
+    RAY_DASHBOARD_ADDRESS,
     RUNTIME_WORKDIR,
     TRIAL_START_TIMEOUT_SECONDS,
 )
@@ -29,8 +30,6 @@ from api.engines.protocol import Engine, TrialConfig
 from api.schemas.common import JobStatus, MDEngine
 
 RAY_RUNTIME_ENV = {"working_dir": RUNTIME_WORKDIR}
-# Ray State API is served by the head pod's dashboard agent (port 8265).
-RAY_DASHBOARD_ADDRESS = f"http://{RAY_ADDRESS.removeprefix('ray://').split(':')[0]}:8265"
 logger = logging.getLogger(__name__)
 
 logger.info("Tuner module initialized")
@@ -114,8 +113,19 @@ _job_context = JobContext()
 TrialConfigEntry = tuple[int, TrialConfig]
 
 
+_init_lock = threading.Lock()
+
+
 def _ensure_ray_initialized() -> None:
-    if not ray.is_initialized():
+    """
+    Connect this worker to the Ray cluster, once per process.
+
+    ray.is_initialized() is unreliable in Ray Client mode, and ClientContext.connect
+    is not thread-safe: concurrent first inits corrupt the client state
+    ("'NoneType' object has no attribute 'connection_info'"). Serialized by a lock;
+    ignore_reinit_error makes re-init on an existing connection a no-op.
+    """
+    with _init_lock:
         ray.init(address=RAY_ADDRESS, runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
         logger.info("Connected to Ray cluster at %s", RAY_ADDRESS)
 

--- a/tuner/api/rayworker/tuner.py
+++ b/tuner/api/rayworker/tuner.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import ray
 from ray.exceptions import RayError
-from ray.util.state import get_task
+from ray.util.state import list_tasks
 
 from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
@@ -20,6 +20,7 @@ from api.db.operations import (
     create_job,
     create_trial_result,
     get_job,
+    get_trials_by_job_id,
     update_job_sim_length,
     update_job_status,
     update_trial_result,
@@ -119,30 +120,39 @@ def _ensure_ray_initialized() -> None:
         logger.info("Connected to Ray cluster at %s", RAY_ADDRESS)
 
 
-def _ray_task_state(future: ray.ObjectRef) -> str | None:
-    """Return the Ray task state for a future, or None if unavailable (never raises)."""
+def _running_trial_ids(job_id: str) -> set[int] | None:
+    """
+    Return the job's trials Ray reports as RUNNING, or None if the State API query failed.
+
+    One filtered query serves all callers: both only care about RUNNING tasks.
+    Query failure is returned distinctly so callers never mistake an outage for
+    "nothing running".
+    """
     try:
-        task = get_task(str(future.task_id()), address=RAY_DASHBOARD_ADDRESS)
-    except Exception:
-        logger.warning("Failed to query Ray task state for %s", future.task_id(), exc_info=True)
+        running_task_ids = {
+            task.task_id for task in list_tasks(filters=[("state", "=", "RUNNING")], address=RAY_DASHBOARD_ADDRESS)
+        }
+    except Exception as e:
+        logger.warning("Ray State API query failed for job %s: %s", job_id, e)
         return None
-    return task.state if task else None
-
-
-def _task_states(job_id: str) -> dict[int, str]:
-    """Return trial ID -> Ray task state for all of the job's active futures."""
-    states: dict[int, str] = {}
-    for future, trial_id in _job_context.get_futures(job_id).items():
-        if state := _ray_task_state(future):
-            states[trial_id] = state
-    return states
+    return {
+        trial_id
+        for future, trial_id in _job_context.get_futures(job_id).items()
+        if str(future.task_id()) in running_task_ids
+    }
 
 
 def trial_status_overrides(job_id: str) -> dict[int, JobStatus]:
-    """Return submitted trials Ray reports as executing (RUNNING)."""
-    return {
-        trial_id: JobStatus.RUNNING for trial_id, state in _task_states(job_id).items() if state.startswith("RUNNING")
-    }
+    """Return submitted trials Ray reports as executing (RUNNING); empty on query failure."""
+    running = _running_trial_ids(job_id)
+    return dict.fromkeys(running, JobStatus.RUNNING) if running is not None else {}
+
+
+def _error_pending_trials(job_id: str) -> None:
+    """Mark non-terminal trials ERROR so a terminal job never leaves dangling PENDING trials."""
+    for trial in get_trials_by_job_id(job_id):
+        if trial.status == JobStatus.PENDING:
+            update_trial_result(trial.id, JobStatus.ERROR, None)
 
 
 def derive_job_status(db_status: JobStatus, trial_statuses: list[JobStatus]) -> JobStatus:
@@ -213,29 +223,32 @@ def _submit_trials(
     return future_to_trial
 
 
-def _fail_if_stalled(job_id: str, future_to_trial: dict[ray.ObjectRef, int], pending_futures: list) -> None:
+def _fail_if_stalled(job_id: str, pending_futures: list) -> None:
     """
     Fail the batch if nothing began within the wait window.
 
-    Executing trials mean progress (keep waiting); nothing executing means
-    unschedulable — cancel the futures, ERROR the trials, and raise.
+    Executing trials mean progress and a State API outage means we cannot tell —
+    both extend the wait. A successful query with nothing RUNNING means the batch
+    never became schedulable: cancel the futures and raise. The trials are swept
+    to ERROR by the caller's failure handler.
     """
-    if any(state.startswith("RUNNING") for state in _task_states(job_id).values()):
+    running = _running_trial_ids(job_id)
+    if running is None:
+        logger.warning("Job %s: cannot verify trial states (State API outage); extending wait", job_id)
+        return
+    if running:
         logger.info(
             "Job %s: no trial completed in %ds but trials are executing; continuing",
             job_id,
             TRIAL_START_TIMEOUT_SECONDS,
         )
         return
-    remaining = [future_to_trial[f] for f in pending_futures]
     logger.warning(
-        "Job %s: no trial began or completed in %ds; failing trials %s", job_id, TRIAL_START_TIMEOUT_SECONDS, remaining
+        "Job %s: no trial began or completed in %ds; failing remaining trials", job_id, TRIAL_START_TIMEOUT_SECONDS
     )
     for future in pending_futures:
         with contextlib.suppress(Exception):
             ray.cancel(future, force=False)
-        update_trial_result(future_to_trial[future], JobStatus.ERROR, None)
-        _job_context.remove_future(job_id, future)
     raise RuntimeError(
         f"No trial began or completed within {TRIAL_START_TIMEOUT_SECONDS}s; cluster busy or unavailable - retry later"
     )
@@ -252,7 +265,7 @@ def _process_trial_results(
     while pending_futures:
         done, pending_futures = ray.wait(pending_futures, num_returns=1, timeout=TRIAL_START_TIMEOUT_SECONDS)
         if not done:
-            _fail_if_stalled(job_id, future_to_trial, pending_futures)
+            _fail_if_stalled(job_id, pending_futures)
             continue
         trial_id = future_to_trial[done[0]]
         try:
@@ -280,16 +293,13 @@ def _process_trial_results(
 def _run_tuning_async(
     job_id: str, engine: Engine, extra_args: str = "", nsteps: int = 25_000, nsteps_override: int | None = None
 ) -> None:
-    pending_trial_ids: list[int] = []
     try:
         # Create trial records before connecting to Ray so GET returns them immediately.
         all_configs = engine.generate_configs()
         trial_configs = [(create_trial_result(job_id, cfg.params, JobStatus.PENDING, None), cfg) for cfg in all_configs]
-        pending_trial_ids = [tid for tid, _ in trial_configs]
         trial_configs = _order_trial_configs(trial_configs)
 
         _ensure_ray_initialized()
-        pending_trial_ids = []  # Ray is up; trials will be managed by the run loop from here
         update_job_status(job_id, JobStatus.RUNNING)
 
         # Full production simulation length for time/cost estimates; failure only degrades estimates.
@@ -325,8 +335,7 @@ def _run_tuning_async(
                 update_job_status(job_id, JobStatus.FINISHED)
     except Exception:
         logger.exception("Tuning job %s failed", job_id)
-        for trial_id in pending_trial_ids:
-            update_trial_result(trial_id, JobStatus.ERROR, None)
+        _error_pending_trials(job_id)
         update_job_status(
             job_id, JobStatus.ERROR, "Tuning job failed. Please try again, or contact support if it persists."
         )
@@ -385,8 +394,10 @@ def sync_job_status(job_id: str) -> JobStatus | None:
         return JobStatus.RUNNING
     if job.status == JobStatus.RUNNING:
         update_job_status(job_id, JobStatus.ERROR, "Job thread terminated unexpectedly")
+        _error_pending_trials(job_id)
         return JobStatus.ERROR
     if job.status == JobStatus.PENDING:
         update_job_status(job_id, JobStatus.ERROR, "Job failed to start - no active thread")
+        _error_pending_trials(job_id)
         return JobStatus.ERROR
     return job.status

--- a/tuner/api/rayworker/tuner.py
+++ b/tuner/api/rayworker/tuner.py
@@ -117,27 +117,14 @@ _init_lock = threading.Lock()
 
 
 def _ensure_ray_initialized() -> None:
-    """
-    Connect this worker to the Ray cluster, once per process.
-
-    ray.is_initialized() is unreliable in Ray Client mode, and ClientContext.connect
-    is not thread-safe: concurrent first inits corrupt the client state
-    ("'NoneType' object has no attribute 'connection_info'"). Serialized by a lock;
-    ignore_reinit_error makes re-init on an existing connection a no-op.
-    """
+    """Connect once per process; client-mode ray.init is not thread-safe, so serialize it."""
     with _init_lock:
         ray.init(address=RAY_ADDRESS, runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
         logger.info("Connected to Ray cluster at %s", RAY_ADDRESS)
 
 
 def _running_trial_ids(job_id: str) -> set[int] | None:
-    """
-    Return the job's trials Ray reports as RUNNING, or None if the State API query failed.
-
-    One filtered query serves all callers: both only care about RUNNING tasks.
-    Query failure is returned distinctly so callers never mistake an outage for
-    "nothing running".
-    """
+    """Trials Ray reports as RUNNING, or None on query failure (distinct from "nothing running")."""
     try:
         running_task_ids = {
             task.task_id for task in list_tasks(filters=[("state", "=", "RUNNING")], address=RAY_DASHBOARD_ADDRESS)
@@ -234,14 +221,7 @@ def _submit_trials(
 
 
 def _fail_if_stalled(job_id: str, pending_futures: list) -> None:
-    """
-    Fail the batch if nothing began within the wait window.
-
-    Executing trials mean progress and a State API outage means we cannot tell —
-    both extend the wait. A successful query with nothing RUNNING means the batch
-    never became schedulable: cancel the futures and raise. The trials are swept
-    to ERROR by the caller's failure handler.
-    """
+    # Outage or executing trials extends the wait; empty RUNNING = batch never schedulable.
     running = _running_trial_ids(job_id)
     if running is None:
         logger.warning("Job %s: cannot verify trial states (State API outage); extending wait", job_id)

--- a/tuner/api/rayworker/tuner.py
+++ b/tuner/api/rayworker/tuner.py
@@ -1,17 +1,20 @@
 """MD engine tuning orchestration using Ray workers."""
 
+import contextlib
 import logging
 import threading
 from typing import Any
 
 import ray
 from ray.exceptions import RayError
+from ray.util.state import get_task
 
 from api.config import (
     EARLY_STOP_BASELINE_TRIALS,
     EARLY_STOP_BATCH_SIZE,
     RAY_ADDRESS,
     RUNTIME_WORKDIR,
+    TRIAL_START_TIMEOUT_SECONDS,
 )
 from api.db.operations import (
     create_job,
@@ -25,6 +28,8 @@ from api.engines.protocol import Engine, TrialConfig
 from api.schemas.common import JobStatus, MDEngine
 
 RAY_RUNTIME_ENV = {"working_dir": RUNTIME_WORKDIR}
+# Ray State API is served by the head pod's dashboard agent (port 8265).
+RAY_DASHBOARD_ADDRESS = f"http://{RAY_ADDRESS.removeprefix('ray://').split(':')[0]}:8265"
 logger = logging.getLogger(__name__)
 
 logger.info("Tuner module initialized")
@@ -37,7 +42,8 @@ class JobState:
         """Store the job thread and initialise cancellation/futures tracking."""
         self.thread = thread
         self.cancelled = threading.Event()
-        self.futures: set[ray.ObjectRef] = set()
+        # Active Ray future -> DB trial ID, so any code path can map task state to trial.
+        self.futures: dict[ray.ObjectRef, int] = {}
 
 
 class JobContext:
@@ -75,8 +81,8 @@ class JobContext:
             event.set()
             return event
 
-    def add_futures(self, job_id: str, futures: set[ray.ObjectRef]) -> None:
-        """Register Ray futures belonging to a job for later cancellation."""
+    def add_futures(self, job_id: str, futures: dict[ray.ObjectRef, int]) -> None:
+        """Register Ray futures belonging to a job for later cancellation and state lookup."""
         with self._lock:
             state = self._jobs.get(job_id)
             if state:
@@ -87,13 +93,13 @@ class JobContext:
         with self._lock:
             state = self._jobs.get(job_id)
             if state:
-                state.futures.discard(future)
+                state.futures.pop(future, None)
 
-    def get_futures(self, job_id: str) -> set[ray.ObjectRef]:
-        """Return a snapshot of all active futures for a job."""
+    def get_futures(self, job_id: str) -> dict[ray.ObjectRef, int]:
+        """Return a snapshot of all active futures for a job as future -> trial ID."""
         with self._lock:
             state = self._jobs.get(job_id)
-            return state.futures.copy() if state else set()
+            return dict(state.futures) if state else {}
 
     def is_thread_alive(self, job_id: str) -> bool:
         """Return True if the job's background thread is still running."""
@@ -111,6 +117,41 @@ def _ensure_ray_initialized() -> None:
     if not ray.is_initialized():
         ray.init(address=RAY_ADDRESS, runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
         logger.info("Connected to Ray cluster at %s", RAY_ADDRESS)
+
+
+def _ray_task_state(future: ray.ObjectRef) -> str | None:
+    """Return the Ray task state for a future, or None if unavailable (never raises)."""
+    try:
+        task = get_task(str(future.task_id()), address=RAY_DASHBOARD_ADDRESS)
+    except Exception:
+        logger.warning("Failed to query Ray task state for %s", future.task_id(), exc_info=True)
+        return None
+    return task.state if task else None
+
+
+def _task_states(job_id: str) -> dict[int, str]:
+    """Return trial ID -> Ray task state for all of the job's active futures."""
+    states: dict[int, str] = {}
+    for future, trial_id in _job_context.get_futures(job_id).items():
+        if state := _ray_task_state(future):
+            states[trial_id] = state
+    return states
+
+
+def trial_status_overrides(job_id: str) -> dict[int, JobStatus]:
+    """Return submitted trials Ray reports as executing (RUNNING)."""
+    return {
+        trial_id: JobStatus.RUNNING for trial_id, state in _task_states(job_id).items() if state.startswith("RUNNING")
+    }
+
+
+def derive_job_status(db_status: JobStatus, trial_statuses: list[JobStatus]) -> JobStatus:
+    """Derive the effective job status; terminal DB statuses always win."""
+    if db_status in {JobStatus.FINISHED, JobStatus.ERROR}:
+        return JobStatus(db_status)
+    if any(s in {JobStatus.RUNNING, JobStatus.FINISHED, JobStatus.ERROR} for s in trial_statuses):
+        return JobStatus.RUNNING
+    return JobStatus.PENDING
 
 
 @ray.remote(max_retries=3)
@@ -167,9 +208,37 @@ def _submit_trials(
             best_steps_per_sec,
         )
         future_to_trial[future] = trial_id
-        update_trial_result(trial_id, JobStatus.RUNNING, None)
-    _job_context.add_futures(job_id, set(future_to_trial.keys()))
+    # Trials stay PENDING until Ray reports RUNNING or the wait loop writes a terminal state.
+    _job_context.add_futures(job_id, future_to_trial)
     return future_to_trial
+
+
+def _fail_if_stalled(job_id: str, future_to_trial: dict[ray.ObjectRef, int], pending_futures: list) -> None:
+    """
+    Fail the batch if nothing began within the wait window.
+
+    Executing trials mean progress (keep waiting); nothing executing means
+    unschedulable — cancel the futures, ERROR the trials, and raise.
+    """
+    if any(state.startswith("RUNNING") for state in _task_states(job_id).values()):
+        logger.info(
+            "Job %s: no trial completed in %ds but trials are executing; continuing",
+            job_id,
+            TRIAL_START_TIMEOUT_SECONDS,
+        )
+        return
+    remaining = [future_to_trial[f] for f in pending_futures]
+    logger.warning(
+        "Job %s: no trial began or completed in %ds; failing trials %s", job_id, TRIAL_START_TIMEOUT_SECONDS, remaining
+    )
+    for future in pending_futures:
+        with contextlib.suppress(Exception):
+            ray.cancel(future, force=False)
+        update_trial_result(future_to_trial[future], JobStatus.ERROR, None)
+        _job_context.remove_future(job_id, future)
+    raise RuntimeError(
+        f"No trial began or completed within {TRIAL_START_TIMEOUT_SECONDS}s; cluster busy or unavailable - retry later"
+    )
 
 
 def _process_trial_results(
@@ -181,7 +250,10 @@ def _process_trial_results(
     new_best = best_steps_per_sec
 
     while pending_futures:
-        done, pending_futures = ray.wait(pending_futures, num_returns=1)
+        done, pending_futures = ray.wait(pending_futures, num_returns=1, timeout=TRIAL_START_TIMEOUT_SECONDS)
+        if not done:
+            _fail_if_stalled(job_id, future_to_trial, pending_futures)
+            continue
         trial_id = future_to_trial[done[0]]
         try:
             res: dict[str, Any] = ray.get(done[0])

--- a/tuner/api/routers/_shared.py
+++ b/tuner/api/routers/_shared.py
@@ -10,12 +10,19 @@ from sqlalchemy.exc import OperationalError
 from starlette.concurrency import run_in_threadpool
 
 from api.auth import verify_credentials
+from api.db.models import Trial
 from api.db.operations import delete_job, get_job, get_trial
-from api.rayworker import cancel_job
-from api.schemas.common import MDEngine
+from api.rayworker import cancel_job, trial_status_overrides
+from api.schemas.common import JobStatus, MDEngine
 from api.utils import cleanup_job_files, read_trial_log
 
 logger = logging.getLogger(__name__)
+
+
+async def effective_trial_statuses(job_id: str, trials: list[Trial]) -> list[JobStatus]:
+    """Apply Ray-ground-truth RUNNING to PENDING trials on top of their DB statuses."""
+    overrides = await run_in_threadpool(trial_status_overrides, job_id)
+    return [overrides.get(t.id, t.status) if t.status == JobStatus.PENDING else t.status for t in trials]
 
 
 async def _get_trial_log(

--- a/tuner/api/routers/amber.py
+++ b/tuner/api/routers/amber.py
@@ -15,8 +15,8 @@ from api.config import INPUTS_DIR, MAX_UPLOAD_SIZE
 from api.db.operations import get_job, get_trials_by_job_id
 from api.engines.amber.config import AmberTrialConfig
 from api.engines.amber.engine import AmberEngine
-from api.rayworker import submit_tuning_job, sync_job_status
-from api.routers._shared import register_job_management_routes
+from api.rayworker import derive_job_status, submit_tuning_job, sync_job_status
+from api.routers._shared import effective_trial_statuses, register_job_management_routes
 from api.schemas.amber import AmberJobStatusResponse, AmberTrialResponse
 from api.schemas.common import JobCreatedResponse, JobStatus, MDEngine
 from api.utils import AMBER_FORBIDDEN_FLAGS, cleanup_job_files, sanitize_extra_args, save_upload
@@ -99,14 +99,15 @@ async def get_amber_status(
         logger.exception("Database timeout for job %s", job_id)
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
 
+    effective_statuses = await effective_trial_statuses(job_id, raw_trials)
     trials = []
-    for t in raw_trials:
+    for t, status in zip(raw_trials, effective_statuses, strict=True):
         cfg = AmberTrialConfig.from_dict(t.config_json)
         estimated_time, estimated_cost = cfg.footprint.estimate(job.sim_length_ns, t.performance)
         trials.append(
             AmberTrialResponse(
                 id=str(t.id),
-                status=t.status,
+                status=status,
                 binary=cfg.binary.value,
                 np=cfg.np,
                 ntomp=cfg.ntomp,
@@ -118,7 +119,11 @@ async def get_amber_status(
         )
 
     return AmberJobStatusResponse(
-        id=job_id, status=job.status, error=job.error, sim_length_ns=job.sim_length_ns, trials=trials
+        id=job_id,
+        status=derive_job_status(job.status, effective_statuses),
+        error=job.error,
+        sim_length_ns=job.sim_length_ns,
+        trials=trials,
     )
 
 

--- a/tuner/api/routers/gmx.py
+++ b/tuner/api/routers/gmx.py
@@ -15,8 +15,8 @@ from api.config import INPUTS_DIR, MAX_UPLOAD_SIZE
 from api.db.operations import get_job, get_trials_by_job_id
 from api.engines.gmx.config import GmxTrialConfig
 from api.engines.gmx.engine import GmxEngine
-from api.rayworker import submit_tuning_job, sync_job_status
-from api.routers._shared import register_job_management_routes
+from api.rayworker import derive_job_status, submit_tuning_job, sync_job_status
+from api.routers._shared import effective_trial_statuses, register_job_management_routes
 from api.schemas.common import JobCreatedResponse, JobStatus, MDEngine
 from api.schemas.gmx import GmxJobStatusResponse, GmxTrialResponse
 from api.utils import GMX_FORBIDDEN_FLAGS, cleanup_job_files, extract_nsteps_override, sanitize_extra_args, save_upload
@@ -87,14 +87,15 @@ async def get_gmx_status(
         logger.exception("Database timeout for job %s", job_id)
         raise HTTPException(status_code=503, detail="Database is busy. Please try again later.") from e
 
+    effective_statuses = await effective_trial_statuses(job_id, raw_trials)
     trials = []
-    for t in raw_trials:
+    for t, status in zip(raw_trials, effective_statuses, strict=True):
         cfg = GmxTrialConfig.from_dict(t.config_json)
         estimated_time, estimated_cost = cfg.footprint.estimate(job.sim_length_ns, t.performance)
         trials.append(
             GmxTrialResponse(
                 id=str(t.id),
-                status=t.status,
+                status=status,
                 ntomp=cfg.ntomp,
                 np=cfg.np,
                 nb=cfg.nb.value,
@@ -106,7 +107,11 @@ async def get_gmx_status(
         )
 
     return GmxJobStatusResponse(
-        id=job_id, status=job.status, error=job.error, sim_length_ns=job.sim_length_ns, trials=trials
+        id=job_id,
+        status=derive_job_status(job.status, effective_statuses),
+        error=job.error,
+        sim_length_ns=job.sim_length_ns,
+        trials=trials,
     )
 
 

--- a/tuner/tests/engines/amber/test_runner.py
+++ b/tuner/tests/engines/amber/test_runner.py
@@ -2,9 +2,47 @@ import signal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from api.config import EARLY_STOP_COST_RATIO, EARLY_STOP_THRESHOLD, EARLY_STOP_WARMUP_STEPS
 from api.engines.amber import runner
 from api.engines.amber.config import AmberBinary, AmberTrialConfig, EwaldPreset
-from api.engines.amber.runner import _parse_amber_performance, _parse_amber_progress, run_pmemd
+from api.engines.amber.runner import _parse_amber_performance, _parse_amber_progress, _should_early_stop, run_pmemd
+
+
+class TestShouldEarlyStop:
+    best_steps = 100.0
+    best_cost_per_step = 0.01
+
+    def stop(self, sps_ratio: float, cost_ratio: float, step: int = EARLY_STOP_WARMUP_STEPS + 1) -> bool:
+        return _should_early_stop(
+            step,
+            120.0,
+            self.best_steps * sps_ratio,
+            self.best_steps,
+            self.best_cost_per_step * cost_ratio,
+            self.best_cost_per_step,
+        )
+
+    def test_slow_but_cheap_explores(self) -> None:
+        assert not self.stop(0.5 * EARLY_STOP_THRESHOLD, 0.5 * EARLY_STOP_COST_RATIO)
+
+    def test_slow_and_expensive_dies(self) -> None:
+        assert self.stop(0.5 * EARLY_STOP_THRESHOLD, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_fast_but_expensive_explores(self) -> None:
+        assert not self.stop(2.0, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_close_but_expensive_dies(self) -> None:
+        assert self.stop(EARLY_STOP_THRESHOLD - 0.05, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_no_prune_before_warmup(self) -> None:
+        step = EARLY_STOP_WARMUP_STEPS - 1
+        assert not _should_early_stop(
+            step, 10.0, self.best_steps * 0.01, self.best_steps, self.best_cost_per_step * 10, self.best_cost_per_step
+        )
+
+    def test_no_prune_without_best_reference(self) -> None:
+        assert not _should_early_stop(EARLY_STOP_WARMUP_STEPS + 1, 120.0, 50.0, 0.0, 0.05, 0.0)
+
 
 SAMPLE_MDOUT = """\
  NSTEP =     5000   TIME(PS) =      10.000  TEMP(K) =   300.12
@@ -50,13 +88,7 @@ def test_monitor_interruption_terminates_native_process_group(tmp_path, monkeypa
 
     with pytest.raises(KeyboardInterrupt):
         runner._run_command_with_monitoring(
-            ["pmemd"],
-            tmp_path / "mdout",
-            tmp_path / "mdinfo",
-            tmp_path,
-            "test trial",
-            0.0,
-            {},
+            ["pmemd"], tmp_path / "mdout", tmp_path / "mdinfo", tmp_path, "test trial", 0.0, {}, 0.0, 0.0
         )
 
     terminate.assert_called_once_with(process, signal.SIGTERM)

--- a/tuner/tests/engines/gmx/test_runner.py
+++ b/tuner/tests/engines/gmx/test_runner.py
@@ -2,7 +2,45 @@ import signal
 from unittest.mock import MagicMock
 
 import pytest
+from api.config import EARLY_STOP_COST_RATIO, EARLY_STOP_THRESHOLD, EARLY_STOP_WARMUP_STEPS
 from api.engines.gmx import runner
+from api.engines.gmx.runner import _should_early_stop
+
+
+class TestShouldEarlyStop:
+    best_steps = 100.0
+    best_cost_per_step = 0.01
+
+    def stop(self, sps_ratio: float, cost_ratio: float, step: int = EARLY_STOP_WARMUP_STEPS + 1) -> bool:
+        return _should_early_stop(
+            step,
+            120.0,
+            self.best_steps * sps_ratio,
+            self.best_steps,
+            self.best_cost_per_step * cost_ratio,
+            self.best_cost_per_step,
+        )
+
+    def test_slow_but_cheap_explores(self) -> None:
+        assert not self.stop(0.5 * EARLY_STOP_THRESHOLD, 0.5 * EARLY_STOP_COST_RATIO)
+
+    def test_slow_and_expensive_dies(self) -> None:
+        assert self.stop(0.5 * EARLY_STOP_THRESHOLD, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_fast_but_expensive_explores(self) -> None:
+        assert not self.stop(2.0, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_close_but_expensive_dies(self) -> None:
+        assert self.stop(EARLY_STOP_THRESHOLD - 0.05, 2 * EARLY_STOP_COST_RATIO)
+
+    def test_no_prune_before_warmup(self) -> None:
+        step = EARLY_STOP_WARMUP_STEPS - 1
+        assert not _should_early_stop(
+            step, 10.0, self.best_steps * 0.01, self.best_steps, self.best_cost_per_step * 10, self.best_cost_per_step
+        )
+
+    def test_no_prune_without_best_reference(self) -> None:
+        assert not _should_early_stop(EARLY_STOP_WARMUP_STEPS + 1, 120.0, 50.0, 0.0, 0.05, 0.0)
 
 
 def test_monitor_interruption_terminates_native_process_group(tmp_path, monkeypatch) -> None:
@@ -15,13 +53,7 @@ def test_monitor_interruption_terminates_native_process_group(tmp_path, monkeypa
 
     with pytest.raises(KeyboardInterrupt):
         runner._run_command_with_monitoring(
-            ["gmx"],
-            tmp_path / "stdout.log",
-            tmp_path / "stderr.log",
-            {},
-            tmp_path,
-            "test trial",
-            0.0,
+            ["gmx"], tmp_path / "stdout.log", tmp_path / "stderr.log", {}, tmp_path, "test trial", 0.0, 0.0, 0.0
         )
 
     terminate.assert_called_once_with(process, signal.SIGTERM)

--- a/tuner/tests/engines/test_protocol.py
+++ b/tuner/tests/engines/test_protocol.py
@@ -21,7 +21,7 @@ def test_engine_protocol_is_structural() -> None:
         def generate_configs(self):
             return []
 
-        def run_trial(self, config, trial_id, job_id, nsteps, extra_args, best_steps_per_sec):
+        def run_trial(self, config, trial_id, job_id, nsteps, extra_args, best_steps_per_sec, best_cost_per_step):
             return TrialResult(performance=0.0, steps_per_sec=0.0, early_stopped=False)
 
         def simulation_length_ns(self, job_id):

--- a/tuner/tests/rayworker/test_tuner.py
+++ b/tuner/tests/rayworker/test_tuner.py
@@ -20,16 +20,17 @@ def job_context(monkeypatch) -> tuner.JobContext:
     return ctx
 
 
-def test_ensure_ray_initialized_uses_single_client_connection(monkeypatch) -> None:
+def test_ensure_ray_initialized_always_inits_and_is_reinit_safe(monkeypatch) -> None:
     ray_mock = Mock()
-    ray_mock.is_initialized.return_value = False
     monkeypatch.setattr(tuner, "ray", ray_mock)
 
     tuner._ensure_ray_initialized()
+    tuner._ensure_ray_initialized()
 
-    ray_mock.init.assert_called_once()
-    _, kwargs = ray_mock.init.call_args
-    assert "allow_multiple" not in kwargs
+    assert ray_mock.init.call_count == 2
+    for call in ray_mock.init.call_args_list:
+        assert call.kwargs["ignore_reinit_error"] is True
+        assert "allow_multiple" not in call.kwargs
 
 
 class TestRunningTrialIds:

--- a/tuner/tests/rayworker/test_tuner.py
+++ b/tuner/tests/rayworker/test_tuner.py
@@ -96,7 +96,7 @@ class TestSubmitTrials:
         cfg = Mock(num_cpus=2, num_gpus=1, params={})
         job_context.add_job("j1", Mock())
 
-        mapping = tuner._submit_trials("j1", "", [(7, cfg)], Mock(), 1000, 0.0)
+        mapping = tuner._submit_trials("j1", "", [(7, cfg)], Mock(), 1000, 0.0, 0.0)
 
         assert mapping == {future: 7}
         tuner.update_trial_result.assert_not_called()
@@ -113,7 +113,7 @@ class TestProcessTrialResultsWatchdog:
         monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: set())
 
         with pytest.raises(RuntimeError, match="cluster busy or unavailable"):
-            tuner._process_trial_results("j1", {future: 7}, 0.0)
+            tuner._process_trial_results("j1", {future: 7}, 0.0, 0.0)
 
         _, kwargs = ray_mock.wait.call_args
         assert kwargs["timeout"] == tuner.TRIAL_START_TIMEOUT_SECONDS
@@ -135,10 +135,44 @@ class TestProcessTrialResultsWatchdog:
         monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: {7})
         monkeypatch.setattr(tuner, "update_trial_result", Mock())
 
-        best = tuner._process_trial_results("j1", {future: 7}, 0.0)
+        best = tuner._process_trial_results("j1", {future: 7}, 0.0, 0.0)
 
-        assert best == 10.0
+        assert best == (10.0, 0.0)
         tuner.update_trial_result.assert_called_once_with(7, JobStatus.FINISHED, 42.0)
+
+    def test_updates_both_champions_from_results(self, job_context, monkeypatch) -> None:
+        future = Mock()
+        ray_mock = Mock()
+        ray_mock.wait.side_effect = [([future], [])]
+        ray_mock.get.return_value = {
+            "trial_id": "7",
+            "status": JobStatus.FINISHED,
+            "performance": 42.0,
+            "steps_per_sec": 10.0,
+            "early_stopped": False,
+            "cost_per_step": 0.5,
+        }
+        monkeypatch.setattr(tuner, "ray", ray_mock)
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+
+        assert tuner._process_trial_results("j1", {future: 7}, 0.0, 0.0) == (10.0, 0.5)
+
+    def test_cheaper_champion_is_not_replaced(self, job_context, monkeypatch) -> None:
+        future = Mock()
+        ray_mock = Mock()
+        ray_mock.wait.side_effect = [([future], [])]
+        ray_mock.get.return_value = {
+            "trial_id": "7",
+            "status": JobStatus.FINISHED,
+            "performance": 42.0,
+            "steps_per_sec": 10.0,
+            "early_stopped": False,
+            "cost_per_step": 0.5,
+        }
+        monkeypatch.setattr(tuner, "ray", ray_mock)
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+
+        assert tuner._process_trial_results("j1", {future: 7}, 20.0, 0.3) == (20.0, 0.3)
 
     def test_state_api_outage_extends_the_window(self, job_context, monkeypatch) -> None:
         """A failed query must never false-kill a progressing job."""
@@ -156,9 +190,9 @@ class TestProcessTrialResultsWatchdog:
         monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: None)
         monkeypatch.setattr(tuner, "update_trial_result", Mock())
 
-        best = tuner._process_trial_results("j1", {future: 7}, 0.0)
+        best = tuner._process_trial_results("j1", {future: 7}, 0.0, 0.0)
 
-        assert best == 10.0
+        assert best == (10.0, 0.0)
         ray_mock.cancel.assert_not_called()
 
 

--- a/tuner/tests/rayworker/test_tuner.py
+++ b/tuner/tests/rayworker/test_tuner.py
@@ -1,6 +1,15 @@
 from unittest.mock import Mock
 
+import pytest
 from api.rayworker import tuner
+from api.schemas.common import JobStatus
+
+
+@pytest.fixture
+def job_context(monkeypatch) -> tuner.JobContext:
+    ctx = tuner.JobContext()
+    monkeypatch.setattr(tuner, "_job_context", ctx)
+    return ctx
 
 
 def test_ensure_ray_initialized_uses_single_client_connection(monkeypatch) -> None:
@@ -13,3 +22,120 @@ def test_ensure_ray_initialized_uses_single_client_connection(monkeypatch) -> No
     ray_mock.init.assert_called_once()
     _, kwargs = ray_mock.init.call_args
     assert "allow_multiple" not in kwargs
+
+
+class TestTaskStates:
+    """_task_states maps active futures to their Ray task states."""
+
+    def test_maps_reported_states(self, job_context, monkeypatch) -> None:
+        future_a, future_b = Mock(), Mock()
+        future_a.task_id.return_value = "task-a"
+        future_b.task_id.return_value = "task-b"
+        job_context.add_job("j1", Mock())
+        job_context.add_futures("j1", {future_a: 1, future_b: 2})
+        monkeypatch.setattr(tuner, "get_task", lambda task_id, address=None: Mock(state="RUNNING"))
+        assert tuner._task_states("j1") == {1: "RUNNING", 2: "RUNNING"}
+
+    def test_skips_unknown_and_failed_queries(self, job_context, monkeypatch) -> None:
+        future_a, future_b, future_c = Mock(), Mock(), Mock()
+        for i, future in enumerate((future_a, future_b, future_c)):
+            future.task_id.return_value = f"task-{i}"
+        job_context.add_job("j1", Mock())
+        job_context.add_futures("j1", {future_a: 1, future_b: 2, future_c: 3})
+
+        def fake_get_task(task_id, address=None):
+            if task_id == "task-0":
+                return Mock(state="RUNNING")
+            if task_id == "task-1":
+                return None  # task not yet visible in GCS
+            raise RuntimeError("dashboard unavailable")
+
+        monkeypatch.setattr(tuner, "get_task", fake_get_task)
+        assert tuner._task_states("j1") == {1: "RUNNING"}
+
+
+class TestTrialStatusOverrides:
+    """trial_status_overrides exposes only trials Ray reports as executing."""
+
+    def test_only_running_states_are_overridden(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            tuner,
+            "_task_states",
+            lambda job_id: {1: "RUNNING", 2: "PENDING_NODE_ASSIGNMENT", 3: "FINISHED"},
+        )
+        assert tuner.trial_status_overrides("j1") == {1: JobStatus.RUNNING}
+
+
+class TestDeriveJobStatus:
+    @pytest.mark.parametrize(
+        ("db_status", "trial_statuses", "expected"),
+        [
+            (JobStatus.FINISHED, [JobStatus.RUNNING], JobStatus.FINISHED),  # terminal wins
+            (JobStatus.ERROR, [JobStatus.RUNNING], JobStatus.ERROR),
+            (JobStatus.RUNNING, [], JobStatus.PENDING),  # nothing executed yet
+            (JobStatus.RUNNING, [JobStatus.PENDING, JobStatus.PENDING], JobStatus.PENDING),
+            (JobStatus.RUNNING, [JobStatus.PENDING, JobStatus.RUNNING], JobStatus.RUNNING),
+            (JobStatus.PENDING, [JobStatus.FINISHED, JobStatus.PENDING], JobStatus.RUNNING),
+            (JobStatus.RUNNING, [JobStatus.ERROR], JobStatus.RUNNING),  # trial error != job terminal
+        ],
+    )
+    def test_derivation(self, db_status, trial_statuses, expected) -> None:
+        assert tuner.derive_job_status(db_status, trial_statuses) == expected
+
+
+class TestSubmitTrials:
+    def test_submission_keeps_trials_pending(self, job_context, monkeypatch) -> None:
+        """Trials stay PENDING until Ray reports execution; no optimistic RUNNING write."""
+        future = Mock()
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+        runner = Mock()
+        runner.options.return_value.remote.return_value = future
+        monkeypatch.setattr(tuner, "_run_single_trial", runner)
+        cfg = Mock(num_cpus=2, num_gpus=1, params={})
+        job_context.add_job("j1", Mock())
+
+        mapping = tuner._submit_trials("j1", "", [(7, cfg)], Mock(), 1000, 0.0)
+
+        assert mapping == {future: 7}
+        tuner.update_trial_result.assert_not_called()
+        assert job_context.get_futures("j1") == {future: 7}
+
+
+class TestProcessTrialResultsWatchdog:
+    def test_stall_fails_remaining_trials_and_raises(self, job_context, monkeypatch) -> None:
+        """No completion in the timeout window and nothing executing => unschedulable."""
+        future = Mock()
+        ray_mock = Mock()
+        ray_mock.wait.return_value = ([], [future])
+        monkeypatch.setattr(tuner, "ray", ray_mock)
+        monkeypatch.setattr(tuner, "_task_states", lambda job_id: {})
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+
+        with pytest.raises(RuntimeError, match="cluster busy or unavailable"):
+            tuner._process_trial_results("j1", {future: 7}, 0.0)
+
+        _, kwargs = ray_mock.wait.call_args
+        assert kwargs["timeout"] == tuner.TRIAL_START_TIMEOUT_SECONDS
+        ray_mock.cancel.assert_called_once_with(future, force=False)
+        tuner.update_trial_result.assert_called_once_with(7, JobStatus.ERROR, None)
+
+    def test_executing_trial_extends_the_window(self, job_context, monkeypatch) -> None:
+        """An executing trial means progress; the watchdog keeps waiting."""
+        future = Mock()
+        ray_mock = Mock()
+        ray_mock.wait.side_effect = [([], [future]), ([future], [])]
+        ray_mock.get.return_value = {
+            "trial_id": "7",
+            "status": JobStatus.FINISHED,
+            "performance": 42.0,
+            "steps_per_sec": 10.0,
+            "early_stopped": False,
+        }
+        monkeypatch.setattr(tuner, "ray", ray_mock)
+        monkeypatch.setattr(tuner, "_task_states", lambda job_id: {7: "RUNNING"})
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+
+        best = tuner._process_trial_results("j1", {future: 7}, 0.0)
+
+        assert best == 10.0
+        tuner.update_trial_result.assert_called_once_with(7, JobStatus.FINISHED, 42.0)

--- a/tuner/tests/rayworker/test_tuner.py
+++ b/tuner/tests/rayworker/test_tuner.py
@@ -1,8 +1,16 @@
 from unittest.mock import Mock
 
 import pytest
+from api.db.models import init_db
+from api.db.operations import create_job, create_trial_result, get_trial, get_trials_by_job_id, update_job_status
 from api.rayworker import tuner
-from api.schemas.common import JobStatus
+from api.schemas.common import JobStatus, MDEngine
+
+
+@pytest.fixture
+def db_schema() -> None:
+    """Ensure the temp DB has tables (init_db runs at app startup, not import)."""
+    init_db()
 
 
 @pytest.fixture
@@ -24,46 +32,39 @@ def test_ensure_ray_initialized_uses_single_client_connection(monkeypatch) -> No
     assert "allow_multiple" not in kwargs
 
 
-class TestTaskStates:
-    """_task_states maps active futures to their Ray task states."""
+class TestRunningTrialIds:
+    """_running_trial_ids intersects the job's futures with one filtered State API query."""
 
-    def test_maps_reported_states(self, job_context, monkeypatch) -> None:
+    def test_maps_running_task_ids_to_trials(self, job_context, monkeypatch) -> None:
         future_a, future_b = Mock(), Mock()
         future_a.task_id.return_value = "task-a"
         future_b.task_id.return_value = "task-b"
         job_context.add_job("j1", Mock())
         job_context.add_futures("j1", {future_a: 1, future_b: 2})
-        monkeypatch.setattr(tuner, "get_task", lambda task_id, address=None: Mock(state="RUNNING"))
-        assert tuner._task_states("j1") == {1: "RUNNING", 2: "RUNNING"}
+        list_tasks_mock = Mock(return_value=[Mock(task_id="task-a")])
+        monkeypatch.setattr(tuner, "list_tasks", list_tasks_mock)
 
-    def test_skips_unknown_and_failed_queries(self, job_context, monkeypatch) -> None:
-        future_a, future_b, future_c = Mock(), Mock(), Mock()
-        for i, future in enumerate((future_a, future_b, future_c)):
-            future.task_id.return_value = f"task-{i}"
-        job_context.add_job("j1", Mock())
-        job_context.add_futures("j1", {future_a: 1, future_b: 2, future_c: 3})
+        assert tuner._running_trial_ids("j1") == {1}
 
-        def fake_get_task(task_id, address=None):
-            if task_id == "task-0":
-                return Mock(state="RUNNING")
-            if task_id == "task-1":
-                return None  # task not yet visible in GCS
-            raise RuntimeError("dashboard unavailable")
+        _, kwargs = list_tasks_mock.call_args
+        assert kwargs["filters"] == [("state", "=", "RUNNING")]
 
-        monkeypatch.setattr(tuner, "get_task", fake_get_task)
-        assert tuner._task_states("j1") == {1: "RUNNING"}
+    def test_query_failure_returns_none(self, job_context, monkeypatch) -> None:
+        monkeypatch.setattr(tuner, "list_tasks", Mock(side_effect=RuntimeError("dashboard unavailable")))
+        assert tuner._running_trial_ids("j1") is None
 
 
 class TestTrialStatusOverrides:
     """trial_status_overrides exposes only trials Ray reports as executing."""
 
-    def test_only_running_states_are_overridden(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            tuner,
-            "_task_states",
-            lambda job_id: {1: "RUNNING", 2: "PENDING_NODE_ASSIGNMENT", 3: "FINISHED"},
-        )
+    def test_running_trials_are_overridden(self, monkeypatch) -> None:
+        monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: {1})
         assert tuner.trial_status_overrides("j1") == {1: JobStatus.RUNNING}
+
+    def test_state_api_outage_yields_empty_overrides(self, monkeypatch) -> None:
+        """Conservative on probe failure: trials render PENDING rather than guessed."""
+        monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: None)
+        assert tuner.trial_status_overrides("j1") == {}
 
 
 class TestDeriveJobStatus:
@@ -102,14 +103,13 @@ class TestSubmitTrials:
 
 
 class TestProcessTrialResultsWatchdog:
-    def test_stall_fails_remaining_trials_and_raises(self, job_context, monkeypatch) -> None:
-        """No completion in the timeout window and nothing executing => unschedulable."""
+    def test_stall_fails_and_cancels_when_nothing_is_running(self, job_context, monkeypatch) -> None:
+        """Successful query + no RUNNING trials after the window => unschedulable."""
         future = Mock()
         ray_mock = Mock()
         ray_mock.wait.return_value = ([], [future])
         monkeypatch.setattr(tuner, "ray", ray_mock)
-        monkeypatch.setattr(tuner, "_task_states", lambda job_id: {})
-        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+        monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: set())
 
         with pytest.raises(RuntimeError, match="cluster busy or unavailable"):
             tuner._process_trial_results("j1", {future: 7}, 0.0)
@@ -117,7 +117,6 @@ class TestProcessTrialResultsWatchdog:
         _, kwargs = ray_mock.wait.call_args
         assert kwargs["timeout"] == tuner.TRIAL_START_TIMEOUT_SECONDS
         ray_mock.cancel.assert_called_once_with(future, force=False)
-        tuner.update_trial_result.assert_called_once_with(7, JobStatus.ERROR, None)
 
     def test_executing_trial_extends_the_window(self, job_context, monkeypatch) -> None:
         """An executing trial means progress; the watchdog keeps waiting."""
@@ -132,10 +131,58 @@ class TestProcessTrialResultsWatchdog:
             "early_stopped": False,
         }
         monkeypatch.setattr(tuner, "ray", ray_mock)
-        monkeypatch.setattr(tuner, "_task_states", lambda job_id: {7: "RUNNING"})
+        monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: {7})
         monkeypatch.setattr(tuner, "update_trial_result", Mock())
 
         best = tuner._process_trial_results("j1", {future: 7}, 0.0)
 
         assert best == 10.0
         tuner.update_trial_result.assert_called_once_with(7, JobStatus.FINISHED, 42.0)
+
+    def test_state_api_outage_extends_the_window(self, job_context, monkeypatch) -> None:
+        """A failed query must never false-kill a progressing job."""
+        future = Mock()
+        ray_mock = Mock()
+        ray_mock.wait.side_effect = [([], [future]), ([future], [])]
+        ray_mock.get.return_value = {
+            "trial_id": "7",
+            "status": JobStatus.FINISHED,
+            "performance": 42.0,
+            "steps_per_sec": 10.0,
+            "early_stopped": False,
+        }
+        monkeypatch.setattr(tuner, "ray", ray_mock)
+        monkeypatch.setattr(tuner, "_running_trial_ids", lambda job_id: None)
+        monkeypatch.setattr(tuner, "update_trial_result", Mock())
+
+        best = tuner._process_trial_results("j1", {future: 7}, 0.0)
+
+        assert best == 10.0
+        ray_mock.cancel.assert_not_called()
+
+
+@pytest.mark.usefixtures("db_schema")
+class TestErrorPendingTrials:
+    def test_marks_only_pending_trials_error(self) -> None:
+        job_id = "sweep-test-job"
+        create_job(job_id, MDEngine.GMX)
+        pending_id = create_trial_result(job_id, {}, JobStatus.PENDING, None)
+        finished_id = create_trial_result(job_id, {}, JobStatus.FINISHED, 10.0)
+
+        tuner._error_pending_trials(job_id)
+
+        statuses = {t.id: t.status for t in get_trials_by_job_id(job_id)}
+        assert statuses[pending_id] == JobStatus.ERROR
+        assert statuses[finished_id] == JobStatus.FINISHED
+
+
+@pytest.mark.usefixtures("db_schema")
+class TestSyncJobStatusSweep:
+    def test_dead_thread_job_errors_and_sweeps_pending_trials(self, job_context) -> None:
+        job_id = "sync-sweep-test-job"
+        create_job(job_id, MDEngine.GMX)
+        trial_id = create_trial_result(job_id, {}, JobStatus.PENDING, None)
+        update_job_status(job_id, JobStatus.RUNNING)  # no registered thread => dead
+
+        assert tuner.sync_job_status(job_id) == JobStatus.ERROR
+        assert get_trial(trial_id, job_id).status == JobStatus.ERROR

--- a/tuner/tests/routers/test_amber.py
+++ b/tuner/tests/routers/test_amber.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from api.main import app
+from api.schemas.common import JobStatus
 from fastapi.testclient import TestClient
 
 client = TestClient(app, raise_server_exceptions=True)
@@ -103,6 +104,58 @@ class TestGetAmberStatus:
         # 100 ns at 50 ns/day -> 48 hours; 8 cores * 0.04 + 16 GB * 0.005 = 0.40/h
         assert t["estimated_time"] == 48.0
         assert t["estimated_cost"] == pytest.approx(19.2)
+
+    @patch("api.routers._shared.trial_status_overrides")
+    @patch("api.routers.amber.get_job")
+    @patch("api.routers.amber.sync_job_status")
+    @patch("api.routers.amber.get_trials_by_job_id")
+    def test_queued_trial_shown_pending(self, mock_trials, mock_sync, mock_get_job, mock_overrides) -> None:
+        job = MagicMock()
+        job.status = "RUNNING"
+        job.engine = "amber"
+        job.error = None
+        job.sim_length_ns = None
+        mock_get_job.return_value = job
+
+        trial = MagicMock()
+        trial.id = 3
+        trial.status = "PENDING"
+        trial.config_json = {"binary": "pmemd.MPI", "np": 4, "ntomp": 2, "ewald": "default"}
+        trial.performance = None
+        mock_trials.return_value = [trial]
+        mock_overrides.return_value = {}
+
+        response = client.get("/api/tuning-jobs/amber/test-id/status", auth=AUTH)
+        assert response.status_code == 200
+        assert response.json()["status"] == "PENDING"
+        [t] = response.json()["trials"]
+        assert t["status"] == "PENDING"
+
+    @patch("api.routers._shared.trial_status_overrides")
+    @patch("api.routers.amber.get_job")
+    @patch("api.routers.amber.sync_job_status")
+    @patch("api.routers.amber.get_trials_by_job_id")
+    def test_ray_running_trial_shown_running(self, mock_trials, mock_sync, mock_get_job, mock_overrides) -> None:
+        job = MagicMock()
+        job.status = "RUNNING"
+        job.engine = "amber"
+        job.error = None
+        job.sim_length_ns = None
+        mock_get_job.return_value = job
+
+        trial = MagicMock()
+        trial.id = 3
+        trial.status = "PENDING"
+        trial.config_json = {"binary": "pmemd.MPI", "np": 4, "ntomp": 2, "ewald": "default"}
+        trial.performance = None
+        mock_trials.return_value = [trial]
+        mock_overrides.return_value = {3: JobStatus.RUNNING}
+
+        response = client.get("/api/tuning-jobs/amber/test-id/status", auth=AUTH)
+        assert response.status_code == 200
+        assert response.json()["status"] == "RUNNING"
+        [t] = response.json()["trials"]
+        assert t["status"] == "RUNNING"
 
     @patch("api.routers.amber.get_job")
     def test_returns_404_for_wrong_engine(self, mock_get_job) -> None:

--- a/tuner/tests/routers/test_gmx.py
+++ b/tuner/tests/routers/test_gmx.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from api.main import app
+from api.schemas.common import JobStatus
 from fastapi.testclient import TestClient
 
 client = TestClient(app, raise_server_exceptions=True)
@@ -67,10 +68,11 @@ class TestCreateGmxTuningJob:
 
 
 class TestGetGmxStatus:
+    @patch("api.routers._shared.trial_status_overrides")
     @patch("api.routers.gmx.get_job")
     @patch("api.routers.gmx.sync_job_status")
     @patch("api.routers.gmx.get_trials_by_job_id")
-    def test_returns_status(self, mock_trials, mock_sync, mock_get_job) -> None:
+    def test_no_executed_trials_reports_pending(self, mock_trials, mock_sync, mock_get_job, mock_overrides) -> None:
         job = MagicMock()
         job.status = "RUNNING"
         job.engine = "gmx"
@@ -78,11 +80,64 @@ class TestGetGmxStatus:
         job.sim_length_ns = 100.0
         mock_get_job.return_value = job
         mock_trials.return_value = []
+        mock_overrides.return_value = {}
+
+        response = client.get("/api/tuning-jobs/gmx/test-id/status", auth=AUTH)
+        assert response.status_code == 200
+        assert response.json()["status"] == "PENDING"
+        assert response.json()["sim_length_ns"] == 100.0
+
+    @patch("api.routers._shared.trial_status_overrides")
+    @patch("api.routers.gmx.get_job")
+    @patch("api.routers.gmx.sync_job_status")
+    @patch("api.routers.gmx.get_trials_by_job_id")
+    def test_queued_trial_shown_pending(self, mock_trials, mock_sync, mock_get_job, mock_overrides) -> None:
+        job = MagicMock()
+        job.status = "RUNNING"
+        job.engine = "gmx"
+        job.error = None
+        job.sim_length_ns = None
+        mock_get_job.return_value = job
+
+        trial = MagicMock()
+        trial.id = 5
+        trial.status = "PENDING"
+        trial.config_json = {"ntomp": 2, "np": 4, "nb": "gpu", "pme": "cpu"}
+        trial.performance = None
+        mock_trials.return_value = [trial]
+        mock_overrides.return_value = {}
+
+        response = client.get("/api/tuning-jobs/gmx/test-id/status", auth=AUTH)
+        assert response.status_code == 200
+        assert response.json()["status"] == "PENDING"
+        [t] = response.json()["trials"]
+        assert t["status"] == "PENDING"
+
+    @patch("api.routers._shared.trial_status_overrides")
+    @patch("api.routers.gmx.get_job")
+    @patch("api.routers.gmx.sync_job_status")
+    @patch("api.routers.gmx.get_trials_by_job_id")
+    def test_ray_running_trial_shown_running(self, mock_trials, mock_sync, mock_get_job, mock_overrides) -> None:
+        job = MagicMock()
+        job.status = "RUNNING"
+        job.engine = "gmx"
+        job.error = None
+        job.sim_length_ns = None
+        mock_get_job.return_value = job
+
+        trial = MagicMock()
+        trial.id = 5
+        trial.status = "PENDING"
+        trial.config_json = {"ntomp": 2, "np": 4, "nb": "gpu", "pme": "cpu"}
+        trial.performance = None
+        mock_trials.return_value = [trial]
+        mock_overrides.return_value = {5: JobStatus.RUNNING}
 
         response = client.get("/api/tuning-jobs/gmx/test-id/status", auth=AUTH)
         assert response.status_code == 200
         assert response.json()["status"] == "RUNNING"
-        assert response.json()["sim_length_ns"] == 100.0
+        [t] = response.json()["trials"]
+        assert t["status"] == "RUNNING"
 
     @patch("api.routers.gmx.get_job")
     @patch("api.routers.gmx.sync_job_status")


### PR DESCRIPTION
## Summary

Implements the approved spec (docs/superpowers/specs/2026-08-10-tuner-job-status-design.md) from the tuner quality review, plus follow-ups surfaced by review and live e2e runs. Trial and job RUNNING status now reflect Ray task ground truth instead of optimistic guesses; a start watchdog bounds the one non-terminating code path (indefinite queue wait); early pruning uses two axes (speed AND cost-per-step) so both the fastest and the most cost-efficient config are always kept; and finished jobs are persisted dashboard-side instead of being polled forever.

## Changes

- **Honest trial status**: `_submit_trials` no longer writes RUNNING at submission. Trials stay PENDING until the read path renders them RUNNING — only while Ray's State API reports the task executing. Queued trials correctly show PENDING.
- **Derived job status**: PENDING until the first trial actually executes, RUNNING monotonically after, FINISHED at grid exhaustion (unchanged), terminal DB statuses always win.
- **Start watchdog**: if `ray.wait` returns nothing for `TRIAL_START_TIMEOUT_SECONDS` (2h, hardcoded), one filtered `list_tasks` State API query decides: trials executing (or an HTTP outage — never a false kill) extends the wait; zero RUNNING on a *successful* query means the batch never became schedulable — futures cancelled, job fails with "cluster busy or unavailable - retry later". Terminal jobs never leave dangling PENDING trials: `_error_pending_trials` sweeps them to ERROR on every failure path.
- **Ray client-mode hardening** (found via live e2e logs): Ray SDK address resolution overrides explicit addresses with `RAY_ADDRESS`, and resolving a `ray://` URL ran a full client connect/disconnect that raced job threads' `ray.init`. Fixed by pinning `RAY_API_SERVER_ADDRESS` to the dashboard HTTP URL (State API stays pure-HTTP) and serializing client init under a lock.
- **Dual-axis pruning**: a trial early-stops only when it is BOTH slower than `EARLY_STOP_THRESHOLD` of the fastest champion AND costlier per step than `EARLY_STOP_COST_RATIO` × the cheapest champion (`cost_per_step = footprint.hourly_cost() / steps_per_sec`). The two champions are tracked independently, so a slow-but-cheap CPU config keeps exploring while a slow-and-expensive one stops early. Speed threshold hardened 65% → 75% since both axes must now fire.
- **UI** (`TunerView`/`AmberTunerView` + tables, unchanged enum/type surface): Stop only while the job isn't stopped; Delete otherwise. Measured-vs-pruned filtering lives in the dashboard API (`preserved_trials`), not client-side; a selection whose trial disappears is cleared.
- **Dashboard API**: a tuner poll returning FINISHED persists the job as stopped (preserving measured trials, deleting it from the tuner). The stopped view IS the finished view — one terminal rendering, no infinite re-polling of completed jobs.
- **Pruning helper shared**: `_should_early_stop` lives in `engines/early_stop.py`, imported by both engine runners (previously duplicated and already drifting).

## Testing

- TDD throughout (RED → GREEN) for state plumbing, derivation, watchdog (stall/extend/outage paths), pending-sweep, dual-axis `_should_early_stop` boundaries, champion tracking, and dashboard FINISHED persistence.
- `make fix`, `make type-check`, `make test` all green (tuner 151, dashboard API 103, remaining harness 62).
- `ruff format --diff` / `ruff check` clean (the exact CI lint-py commands).
- **Live e2e on dev (`make -C tuner e2e ENV=dev`): 3/3 passed (~13 min) against the pushed `dev` image** — real GMX+AMBER jobs through submission, dual-axis pruning paths, polling, and deletion, with zero client-mode errors in the pod logs.

## Not in scope

- "Explored x of N" trial counters: already possible client-side (all grid trials are created PENDING up-front and are all present in the status payload), no tuner change needed.
- Per-trial wedge detection for a RUNNING trial that never completes (accepted gap documented in the spec).

